### PR TITLE
First cut at updating README files to support CD.x and 7.x releases

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@
 include::shared-doc/attributes.adoc[]
 
 [abstract]
-The quickstarts demonstrate Java EE 7 and a few additional technologies from the JBoss stack. They provide small, specific, working examples that can be used as a reference for your own project.
+The quickstarts demonstrate {javaVersion} and a few additional technologies from the JBoss stack. They provide small, specific, working examples that can be used as a reference for your own project.
 
 [[introduction]]
 == Introduction
@@ -47,14 +47,14 @@ NOTE: Some of these quickstarts use the H2 database included with {productName}.
 //<TOC>
 [cols="1,1,2,1,1", options="header"]
 |===
-| Quickstart Name | Demonstrated Technologies | Description | Experience Level Required | Prerequisites
+| Quickstart Name | Demonstrated Technologies | Description | Experience Level Required | Prerequisites 
 | link:app-client/README{outfilesuffix}[app-client]|EJB, EAR, AppClient | The `app-client` quickstart demonstrates how to code and package a client app and use the {productName} client container to start the client `Main` program. | Intermediate | _none_
 | link:batch-processing/README{outfilesuffix}[batch-processing]|CDI, Batch 1.0, JSF | The `batch-processing` quickstart shows how to use chunk oriented batch jobs to import a file to a database. | Intermediate | _none_
 | link:bean-validation/README{outfilesuffix}[bean-validation]|CDI, JPA, BV | The `bean-validation` quickstart provides Arquillian tests to demonstrate how to use CDI, JPA, and Bean Validation. | Beginner | _none_
 | link:bean-validation-custom-constraint/README{outfilesuffix}[bean-validation-custom-constraint]|CDI, JPA, BV | The `bean-validation-custom-constraint` quickstart demonstrates how to use the Bean Validation API to define custom constraints and validators. | Beginner | _none_
 | link:bmt/README{outfilesuffix}[bmt]|EJB, BMT | The `bmt` quickstart demonstrates Bean-Managed Transactions (BMT), showing how to manually manage transaction demarcation while accessing JPA entities. | Intermediate | _none_
 | link:cmt/README{outfilesuffix}[cmt]|EJB, CMT, JMS | The `cmt` quickstart demonstrates Container-Managed Transactions (CMT), showing how to use transactions managed by the container. | Intermediate | _none_
-| link:contacts-jquerymobile/README{outfilesuffix}[contacts-jquerymobile]|jQuery Mobile, jQuery, JavaScript, HTML5, REST | The `contacts-jquerymobile` quickstart demonstrates a Java EE 7 mobile database application using HTML5, jQuery Mobile, JAX-RS, JPA, and REST. | Beginner | _none_
+| link:contacts-jquerymobile/README{outfilesuffix}[contacts-jquerymobile]|jQuery Mobile, jQuery, JavaScript, HTML5, REST | The `contacts-jquerymobile` quickstart demonstrates a {javaVersion} mobile database application using HTML5, jQuery Mobile, JAX-RS, JPA, and REST. | Beginner | _none_
 | link:deltaspike-authorization/README{outfilesuffix}[deltaspike-authorization]|JSF, CDI, Deltaspike | Demonstrate the creation of a custom authorization example using @SecurityBindingType from DeltaSpike | Beginner | _none_
 | link:deltaspike-beanbuilder/README{outfilesuffix}[deltaspike-beanbuilder]|CDI, DeltaSpike | Shows how to create new beans using DeltaSpike utilities. | Advanced | _none_
 | link:deltaspike-projectstage/README{outfilesuffix}[deltaspike-projectstage]|JSF, CDI, Deltaspike | Demonstrate usage of DeltaSpike project stage and shows usage of a conditional @Exclude | Beginner | _none_
@@ -100,11 +100,11 @@ NOTE: Some of these quickstarts use the H2 database included with {productName}.
 | link:jta-crash-rec/README{outfilesuffix}[jta-crash-rec]|JTA, Crash Recovery | The `jta-crash-rec` quickstart uses JTA and Byteman to show how to code distributed (XA) transactions in order to preserve ACID properties on server crash. | Advanced | _none_
 | link:jts/README{outfilesuffix}[jts]|JTS, EJB, JMS | The `jts` quickstart shows how to use JTS to perform distributed transactions across multiple containers, fulfilling the properties of an ACID transaction. | Intermediate | link:cmt/README{outfilesuffix}[cmt]
 | link:jts-distributed-crash-rec/README{outfilesuffix}[jts-distributed-crash-rec]|JTS, Crash Recovery | The `jts-distributed-crash-rec` quickstart uses JTS and Byteman to demonstrate distributed crash recovery across multiple application servers. | Advanced | link:jts/README{outfilesuffix}[jts]
-| link:kitchensink/README{outfilesuffix}[kitchensink]|CDI, JSF, JPA, EJB, JAX-RS, BV | The `kitchensink` quickstart demonstrates a Java EE 7 web-enabled database application using JSF, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
-| link:kitchensink-angularjs/README{outfilesuffix}[kitchensink-angularjs]|AngularJS, CDI, JPA, EJB, JPA, JAX-RS, BV | The `kitchensink-angularjs` quickstart demonstrates a Java EE 7 application using AngularJS with JAX-RS, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
+| link:kitchensink/README{outfilesuffix}[kitchensink]|CDI, JSF, JPA, EJB, JAX-RS, BV | The `kitchensink` quickstart demonstrates a {javaVersion} web-enabled database application using JSF, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
+| link:kitchensink-angularjs/README{outfilesuffix}[kitchensink-angularjs]|AngularJS, CDI, JPA, EJB, JPA, JAX-RS, BV | The `kitchensink-angularjs` quickstart demonstrates a {javaVersion} application using AngularJS with JAX-RS, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
 | link:kitchensink-ear/README{outfilesuffix}[kitchensink-ear]|CDI, JSF, JPA, EJB, JAX-RS, BV, EAR | The `kitchensink-ear` quickstart demonstrates web-enabled database application, using JSF, CDI, EJB, JPA, and Bean Validation, packaged as an EAR. | Intermediate | _none_
 | link:kitchensink-jsp/README{outfilesuffix}[kitchensink-jsp]|JSP, JSTL, CDI, JPA, EJB, JAX-RS, BV | The `kitchensink-jsp` quickstart demonstrates how to use JSP, JSTL, CDI, EJB, JPA, and Bean Validation in {productName}. | Intermediate | _none_
-| link:kitchensink-ml/README{outfilesuffix}[kitchensink-ml]|CDI, JSF, JPA, EJB, JAX-RS, BV, i18n, l10n | The `kitchensink-ml` quickstart demonstrates a localized Java EE 7 compliant application using JSF, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
+| link:kitchensink-ml/README{outfilesuffix}[kitchensink-ml]|CDI, JSF, JPA, EJB, JAX-RS, BV, i18n, l10n | The `kitchensink-ml` quickstart demonstrates a localized {javaVersion} compliant application using JSF, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
 | link:kitchensink-utjs-angularjs/README{outfilesuffix}[kitchensink-utjs-angularjs]|Undertow.js, Angular.js | Based on kitchensink, but uses a Angular for the front end and Undertow.js for the back end. | Intermediate | _none_
 | link:kitchensink-utjs-mustache/README{outfilesuffix}[kitchensink-utjs-mustache]|Undertow.js, Mustache | Based on kitchensink, but uses Mustache for the front end and Undertow.js for the back end. | Intermediate | _none_
 | link:logging/README{outfilesuffix}[logging]|Logging | The `logging` quickstart demonstrates how to configure different logging levels in {productName}. It also includes an asynchronous logging example. | Intermediate | _none_
@@ -120,9 +120,9 @@ NOTE: Some of these quickstarts use the H2 database included with {productName}.
 | link:servlet-async/README{outfilesuffix}[servlet-async]|Asynchronous Servlet, CDI, EJB | The `servlet-async` quickstart demonstrates how to use asynchronous servlets to detach long-running tasks and free up the request processing thread. | Intermediate | _none_
 | link:servlet-filterlistener/README{outfilesuffix}[servlet-filterlistener]|Servlet Filter, Servlet Listener | The `servlet-filterlistener` quickstart demonstrates how to use Servlet filters and listeners in an application. | Intermediate | _none_
 | link:servlet-security/README{outfilesuffix}[servlet-security]|Servlet, Security | The `servlet-security` quickstart demonstrates the use of Java EE declarative security to control access to Servlets and Security in {productName}. | Intermediate | _none_
-| link:shopping-cart/README{outfilesuffix}[shopping-cart]|SFSB EJB | The `shopping-cart` quickstart demonstrates how to deploy and run a simple Java EE 7 shopping cart application that uses a stateful session bean (SFSB). | Intermediate | _none_
+| link:shopping-cart/README{outfilesuffix}[shopping-cart]|SFSB EJB | The `shopping-cart` quickstart demonstrates how to deploy and run a simple {javaVersion} shopping cart application that uses a stateful session bean (SFSB). | Intermediate | _none_
 | link:spring-greeter/README{outfilesuffix}[spring-greeter]|Spring MVC, JSP, JPA | The `spring-greeter` quickstart is based on the `greeter` quickstart, but differs in that it uses Spring MVC for Mapping `GET` and `POST` requests. | Beginner | _none_
-| link:spring-kitchensink-basic/README{outfilesuffix}[spring-kitchensink-basic]|JSP, JPA, JSON, Spring, JUnit | The `spring-kitchensink-basic` quickstart is an example of a Java EE 7 application using JSP, JPA and Spring 4.x. | Intermediate | _none_
+| link:spring-kitchensink-basic/README{outfilesuffix}[spring-kitchensink-basic]|JSP, JPA, JSON, Spring, JUnit | The `spring-kitchensink-basic` quickstart is an example of a {javaVersion} application using JSP, JPA and Spring 4.x. | Intermediate | _none_
 | link:spring-kitchensink-springmvctest/README{outfilesuffix}[spring-kitchensink-springmvctest]|JSP, JPA, JSON, Spring, JUnit | The  `spring-kitchensink-springmvctest` quickstart demonstrates how to create an MVC application using JSP, JPA and Spring 4.x. | Intermediate | _none_
 | link:spring-resteasy/README{outfilesuffix}[spring-resteasy]|Resteasy, Spring | The `spring-resteasy` quickstart demonstrates how to package and deploy a web application that includes resteasy-spring integration. | Beginner | _none_
 | link:tasks-jsf/README{outfilesuffix}[tasks-jsf]|JSF, JPA | The `tasks-jsf` quickstart demonstrates how to use JPA persistence with JSF as the view layer. | Intermediate | link:tasks/README{outfilesuffix}[tasks]

--- a/contacts-jquerymobile/README.adoc
+++ b/contacts-jquerymobile/README.adoc
@@ -12,14 +12,14 @@ include::../shared-doc/attributes.adoc[]
 :source: {githubRepoUrl}
 
 [abstract]
-The `contacts-jquerymobile` quickstart demonstrates a Java EE 7 mobile database application using HTML5, jQuery Mobile, JAX-RS, JPA, and REST.
+The `contacts-jquerymobile` quickstart demonstrates a {javaVersion} mobile database application using HTML5, jQuery Mobile, JAX-RS, JPA, and REST.
 
 :standalone-server-type: default
 :archiveType: war
 
 == What is it?
 
-The `contact-jquerymobile` quickstart is a deployable Maven 3 project designed to help you get your foot in the door developing HTML5 based mobile web applications with Java EE 7 in {productNameFull}. This project is setup to allow you to create a basic Java EE 7 application using HTML5, jQuery Mobile, JAX-RS, CDI, EJB, JPA, and Bean Validation. It includes a persistence unit and some sample persistence and transaction code to help you get your feet wet with database access in enterprise Java.
+The `contact-jquerymobile` quickstart is a deployable Maven 3 project designed to help you get your foot in the door developing HTML5 based mobile web applications with {javaVersion} in {productNameFull}. This project is setup to allow you to create a basic {javaVersion} application using HTML5, jQuery Mobile, JAX-RS, CDI, EJB, JPA, and Bean Validation. It includes a persistence unit and some sample persistence and transaction code to help you get your feet wet with database access in enterprise Java.
 
 This application is built using a HTML5 + REST approach. This uses a pure HTML client that interacts with with the application server via restful end-points (JAX-RS). This application also uses some of the latest HTML5 features and advanced JAX-RS. And since testing is just as important with client side as it is server side, this application uses QUnit to show you how to unit test your JavaScript.
 

--- a/dist/buildReadmes.sh
+++ b/dist/buildReadmes.sh
@@ -1,0 +1,106 @@
+## asciidoctor -t -dbook -a toc -o README.html README.adoc
+## cd shared-doc/
+## asciidoctor -t -dbook -a toc -o development-shortcuts.html development-shortcuts.adoc
+## asciidoctor -t -dbook -a toc -o system-requirements.html system-requirements.adoc
+## cd ../kitchensink
+## asciidoctor -t -dbook -a toc -o README.html README.adoc
+## cd ../
+
+usage(){
+  cat <<EOM
+USAGE: $0 [OPTION]... <guide>
+
+DESCRIPTION: Build all of the guides (default), a single guide, and (optionally)
+produce pot/po files for translation.
+
+Run this script from the root of your cloned repo or from the 'scripts'
+directory.  Example:
+  cd eap-quickstart/
+  $0
+
+OPTIONS:
+  -h       Print help.
+
+EXAMPLES:
+  Build all quickstarts:
+   $0
+
+  Build a specific quickstart(s):
+    $0 kitchensink
+    $0 kitchensink number-guess
+
+EOM
+# Now list the valid quickstart names
+listquickstarts
+}
+
+
+listquickstarts(){
+  echo ""
+  echo "  Valid book argument values are:"
+
+  subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "dist" ! -iname "shared" ! -iname "src" | sort`
+  for subdir in $subdirs
+  do
+    echo "   ${subdir##*/}"
+  done
+  echo ""
+  # Return to where we started as a courtesy.
+}
+
+
+OPTIND=1
+while getopts "ht" c
+ do
+     case "$c" in
+       h)         usage
+                  exit 1;;
+       \?)        echo "Unknown option: -$OPTARG." >&2
+                  usage
+                  exit 1;;
+     esac
+ done
+shift $(($OPTIND - 1))
+
+
+CURRENT_DIR="$( pwd -P)"
+SCRIPT_SRC="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
+QS_BASE="$( dirname $SCRIPT_SRC )"
+
+echo "CURRENT_DIR = $CURRENT_DIR"
+echo "SCRIPT_SRC = $SCRIPT_SRC"
+echo "QS_BASE = $QS_BASE"
+
+# Set the list of quickstart README files to build to whatever the user passed in (if anyting)
+cd $QS_BASE
+
+subdirs=$@
+if [ $# -gt 0 ]; then
+  # Strip off any ending forward slash
+  subdirs=${@%/}
+  echo "=== Bulding $subdirs ==="
+else
+  echo "=== Building all the quickstarts ==="
+  # Build the root README first
+  asciidoctor -t -dbook -a toc -o README.html README.adoc
+  # Recurse through the guide directories and build them.
+  subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "dist" ! -iname "shared" | sort`
+fi
+echo $PWD
+for subdir in $subdirs
+do
+  echo "Building ${subdir##*/}"
+  # Navigate to the dirctory and build it
+  if ! [ -e ${subdir##*/} ]; then
+    BUILD_MESSAGE="$BUILD_MESSAGE\nERROR: ${subdir##*/} does not exist."
+    # This is a book argument error so we should list the valid arguments.
+    LIST_BOOKS="true"
+    continue
+  fi
+  cd ${subdir##*/}
+  GUIDE_NAME=${PWD##*/}
+  asciidoctor -t -dbook -a toc -o README.html README.adoc
+  # Return to the parent directory
+  cd $QS_BASE
+done
+

--- a/helloworld-rf/README.adoc
+++ b/helloworld-rf/README.adoc
@@ -16,7 +16,7 @@ Similar to the helloworld quickstart, but with a JSF front end
 
 == What is it?
 
-This project demonstrates how to create a Java EE 7 compliant application using JSF 2.2, CDI 1.2, and RichFaces 4.5.
+This project demonstrates how to create a {javaVersion} compliant application using JSF 2.2, CDI 1.2, and RichFaces 4.5.
 
 In this example, a standard JSF `h:inputText` component is AJAX enabled using the RichFaces `a4j:ajax tag`. This triggers the application server to re-render only a subsection of the page on a browser event.
 

--- a/hibernate/README.adoc
+++ b/hibernate/README.adoc
@@ -21,7 +21,7 @@ The `hibernate` quickstart demonstrates how to use Hibernate ORM 5 API over JPA,
 
 The `hibernate` quickstart is based upon the link:../kitchensink/README{outfilesuffix}[kitchensink] example, but demonstrates how to use Hibernate Object/Relational Mapping (ORM) 5 over JPA in {productNameFull}.
 
-This project is setup to allow you to create a compliant Java EE 7 application using JSF, CDI, EJB, JPA , Hibernate-Core and Hibernate Bean Validation. It includes a persistence unit associated with Hibernate session and some sample persistence and transaction code to help you with database access in enterprise Java.
+This project is setup to allow you to create a compliant {javaVersion} application using JSF, CDI, EJB, JPA , Hibernate-Core and Hibernate Bean Validation. It includes a persistence unit associated with Hibernate session and some sample persistence and transaction code to help you with database access in enterprise Java.
 
 //*************************************************
 // Add notes about use in a production environment.

--- a/hibernate4/README.adoc
+++ b/hibernate4/README.adoc
@@ -18,7 +18,7 @@ This quickstart performs the same functions as the _hibernate_ quickstart, but u
 
 This quickstart is based upon the kitchensink example, but demonstrates how to use Hibernate ORM 4 over JPA in JBoss WildFly.
 
-This project is setup to allow you to create a compliant Java EE 7 application using JSF 2.2, CDI 1.1, EJB 3.2, JPA 2.1 , Hibernate-Core and Hibernate Bean Validation. It includes a persistence unit associated with Hibernate session and some sample persistence and transaction code to help you with database access in enterprise Java.
+This project is setup to allow you to create a compliant {javaVersion} application using JSF 2.2, CDI 1.1, EJB 3.2, JPA 2.1 , Hibernate-Core and Hibernate Bean Validation. It includes a persistence unit associated with Hibernate session and some sample persistence and transaction code to help you with database access in enterprise Java.
 
 You can compare this quickstart to the `hibernate` quickstart, which uses Hibernate 5, to see the code differences between Hibernate 4 and Hibernate 5.
 

--- a/kitchensink-angularjs/README.adoc
+++ b/kitchensink-angularjs/README.adoc
@@ -12,16 +12,16 @@ include::../shared-doc/attributes.adoc[]
 :source: {githubRepoUrl}
 
 [abstract]
-The `kitchensink-angularjs` quickstart demonstrates a Java EE 7 application using AngularJS with JAX-RS, CDI, EJB, JPA, and Bean Validation.
+The `kitchensink-angularjs` quickstart demonstrates a {javaVersion} application using AngularJS with JAX-RS, CDI, EJB, JPA, and Bean Validation.
 
 :standalone-server-type: default
 :archiveType: war
 
 == What is it?
 
-The `kitchensink-angularjs` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with AngularJS on Java EE 7 with {productNameFull}.
+The `kitchensink-angularjs` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with AngularJS on {javaVersion} with {productNameFull}.
 
-This project is setup to allow you to create a compliant Java EE 7 application using CDI 1.2, EJB 3.2, JPA 2.1 and Bean Validation 1.1. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
+This project is setup to allow you to create a compliant {javaVersion} application using CDI 1.2, EJB 3.2, JPA 2.1 and Bean Validation 1.1. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
 
 //*************************************************
 // Add System Requirements

--- a/kitchensink-ear/README.adoc
+++ b/kitchensink-ear/README.adoc
@@ -1,4 +1,4 @@
-= kitchensink-ear: Using Multiple Java EE 7 Technologies Deployed as an EAR
+= kitchensink-ear: Using Multiple {javaVersion} Technologies Deployed as an EAR
 :author: Pete Muir
 :productName: WildFly
 :productNameFull: WildFly Application Server
@@ -19,9 +19,9 @@ The `kitchensink-ear` quickstart demonstrates web-enabled database application, 
 
 == What is it?
 
-The `kitchensink-ear` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with Java EE 7 on {productNameFull}.
+The `kitchensink-ear` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with {javaVersion} on {productNameFull}.
 
-It demonstrates how to create a compliant Java EE 7 application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java. It is based on the link:../kitchensink/README.adoc[kitchensink] quickstart but is packaged as an EAR archive.
+It demonstrates how to create a compliant {javaVersion} application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java. It is based on the link:../kitchensink/README.adoc[kitchensink] quickstart but is packaged as an EAR archive.
 
 //*************************************************
 // Add notes about use in a production environment.

--- a/kitchensink-jsp/README.adoc
+++ b/kitchensink-jsp/README.adoc
@@ -19,7 +19,7 @@ The `kitchensink-jsp` quickstart demonstrates how to use JSP, JSTL, CDI, EJB, JP
 
 == What is it?
 
-The `kitchensink-jsp` quickstart is a deployable Maven 3 project and demonstrates how to create a compliant Java EE 7 application using JSP 2.0, EL 2.0, JSTL 1.2, CDI, EJB, JPA, and Bean Validation in {productNameFull}.
+The `kitchensink-jsp` quickstart is a deployable Maven 3 project and demonstrates how to create a compliant {javaVersion} application using JSP 2.0, EL 2.0, JSTL 1.2, CDI, EJB, JPA, and Bean Validation in {productNameFull}.
 
 This example is based on the link:../kitchensink/README.adoc[kitchensink] quickstart, but recreates the presentation tier using JSP and JSTL instead of JSF features. It reuses all other components from the Member Registration template. It also reuses the persistence unit and some sample persistence and transaction code to help you with database access in enterprise Java.
 

--- a/kitchensink-ml/README.adoc
+++ b/kitchensink-ml/README.adoc
@@ -12,16 +12,16 @@ include::../shared-doc/attributes.adoc[]
 :source: {githubRepoUrl}
 
 [abstract]
-The `kitchensink-ml` quickstart demonstrates a localized Java EE 7 compliant application using JSF, CDI, EJB, JPA, and Bean Validation.
+The `kitchensink-ml` quickstart demonstrates a localized {javaVersion} compliant application using JSF, CDI, EJB, JPA, and Bean Validation.
 
 :standalone-server-type: default
 :archiveType: war
 
 == What is it?
 
-The `kitchensink-ml` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with Java EE 7 on {productNameFull}.
+The `kitchensink-ml` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with {javaVersion} on {productNameFull}.
 
-It demonstrates how to create a _localized_ Java EE 7 compliant application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. A localized application is one that supports multiple languages. That is what the _-ml_ suffix denotes in the quickstart name _kitchensink-ml_. This quickstart also includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
+It demonstrates how to create a _localized_ {javaVersion} compliant application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. A localized application is one that supports multiple languages. That is what the _-ml_ suffix denotes in the quickstart name _kitchensink-ml_. This quickstart also includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
 
 This quickstart uses the link:../kitchensink/README{outfilesuffix}[kitchensink] quickstart as its starting point. It has been enhanced to provide localization of labels and messages. A user sets the preferred language choice in the browser and, if the application supports that language, the application web page is rendered in that language. For demonstration purposes, this quickstart has been tranlated into French(fr) and Spanish (es) using http://translate.google.com, so the translations may not be ideal.
 

--- a/kitchensink-utjs-angularjs/README.adoc
+++ b/kitchensink-utjs-angularjs/README.adoc
@@ -18,7 +18,7 @@ Based on kitchensink, but uses a Angular for the front end and Undertow.js for t
 
 This quickstart is a deployable Maven 3 project to help you get your foot in the door developing with Undertow.js and Java EE7 on JBoss WildFly.
 
-This project is setup to allow you to create a compliant Java EE 7 application using Undertow.js CDI 1.1, JPA 2.1 and Bean Validation 1.1. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in Undertow.js.
+This project is setup to allow you to create a compliant {javaVersion} application using Undertow.js CDI 1.1, JPA 2.1 and Bean Validation 1.1. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in Undertow.js.
 
 == System requirements
 

--- a/kitchensink/README.adoc
+++ b/kitchensink/README.adoc
@@ -12,52 +12,74 @@ include::../shared-doc/attributes.adoc[]
 :source: {githubRepoUrl}
 
 [abstract]
-The `kitchensink` quickstart demonstrates a Java EE 7 web-enabled database application using JSF, CDI, EJB, JPA, and Bean Validation.
+The `kitchensink` quickstart demonstrates a {javaVersion} web-enabled database application using JSF, CDI, EJB, JPA, and Bean Validation.
 
 :standalone-server-type: default
 :archiveType: war
 :uses-h2:
 :uses-ds-xml:
 
+//*************************************************
+// CD and Product Release content
+//*************************************************
+
+
 == What is it?
 
-The `kitchensink` quickstart is a deployable Maven 3 project designed to help you get your foot in the door developing with Java EE 7 on {productNameFull}.
+The `kitchensink` quickstart is a deployable Maven 3 project designed to help you get your foot in the door developing with {javaVersion} on {productNameFull}.
 
-It demonstrates how to create a compliant Java EE 7 application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. It also includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
+It demonstrates how to create a compliant {javaVersion} application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. It also includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
 
 //*************************************************
-// Add notes about use in a production environment.
+// CD Release content
 //*************************************************
-// == Considerations for Use in a Production Environment
+
+ifdef::EAPCDRelease[]
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+
+// OpenShift Post Deployment Tasks
+include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+
+
+//*************************************************
+// Product Release content
+//*************************************************
+
+ifndef::EAPCDRelease[]
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+//  Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+//  Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+//  Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
 
 The application will be running at the following URL: http://localhost:8080/{artifactId}/.
+
+endif::[]
+
+
+//*************************************************
+// CD and Product Release content
+//*************************************************
 
 == Server Log: Expected Warnings and Errors
 
@@ -71,31 +93,19 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 ----
 
 //*************************************************
-// Undeploy the quickstart archive
+// Product Release instructions
 //*************************************************
-// == Undeploy the Quickstart
+
+ifndef::EAPCDRelease[]
+
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+//  Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Deploy the Quickstart to OpenShift Online
+// include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+endif::[]

--- a/shared-doc/attributes.adoc
+++ b/shared-doc/attributes.adoc
@@ -1,10 +1,65 @@
+//*************************
+// CD release values
+//*************************
+// The following attribute is a flag build READMEs for the CD release instructions.
+// Comment it out to build the READMEs for the Product releases
+//:EAPCDRelease:
+// Additional CD attribute definitions
+// Attributes for CD releases
+:CDProductName: JBoss Enterprise Application Platform continuous delivery
+:CDProductShortName: {ProductShortName} Continuous Delivery
+:CDProductTitle: JBoss Enterprise Application Platform Continuous Delivery
+:CDProductNameSentence: continuous delivery release for {ProductShortName}
+:CDProductAcronym: JBoss EAP CD
+:CDProductVersion: 13
+:EapForOpenshiftBookName: Red Hat JBoss Enterprise Application Platform for OpenShift
+:EapForOpenshiftOnlineBookName: Red Hat JBoss Enterprise Application Platform for OpenShift Online
+:xpaasproduct: Red Hat JBoss Enterprise Application Platform for OpenShift
+:xpaasproductOpenShiftOnline: Red Hat JBoss Enterprise Application Platform for OpenShift Online
+:xpaasproduct-shortname: JBoss EAP for OpenShift
+:xpaasproductOpenShiftOnline-shortname: JBoss EAP for OpenShift Online
+:EapForOpenshiftBookName: Red Hat JBoss Enterprise Application Platform for OpenShift
+:EapForOpenshiftOnlineBookName: Red Hat JBoss Enterprise Application Platform for OpenShift Online
+:ImagePrefixVersion: eap71
+
+// Repo and reference for quickstart kitchensink procedure
+:EAPQuickStartRepo: https://github.com/jboss-developer/jboss-eap-quickstarts
+:EAPQuickStartRepoRef: 7.1.0.GA
+
+// Product names and links are dependent on whether it is a CD or a 7.x product release
+// The "DocInfo..." attributes are used to build the book links
+ifdef::EAPCDRelease[]
+:productName: {xpaasproduct}
+:productNameFull: {xpaasproduct-shortname}
+:DocInfoProductNameURL: jboss_enterprise_application_platform_continuous_delivery
+:DocInfoProductName: JBoss Enterprise Application Platform Continuous Delivery
+:DocInfoProductNumber: 13
+:ImageandTemplateImportURL: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/
+endif::[]
+ifndef::EAPCDRelease[]
 :productName: WildFly
 :productNameFull: WildFly Application Server
+:DocInfoProductName: red_hat_jboss_enterprise_application_platform
+:DocInfoProductNameURL: red_hat_jboss_enterprise_application_platform
+:DocInfoProductNumber: 7.1
+:DocInfoPreviousProductName: jboss-enterprise-application-platform
+:ImageandTemplateImportURL: https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/
+endif::[]
+
+
+// Links to the OpenShift documentation
+:LinkOpenShiftGuide: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/getting_started_with_jboss_eap_for_openshift_container_platform/
+:LinkOpenShiftOnlineGuide: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/getting_started_with_jboss_eap_for_openshift_online/
+
+//*************************
+// Product and other values
+//*************************
 :jbossHomeName: WILDFLY_HOME
 :productVersion: 12
 :ProductShortName: JBoss EAP
 :buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 :jbdsEapServerName: Red Hat JBoss Enterprise Application Platform 7.1
+:javaVersion: Java EE 8
 :githubRepoUrl: https://github.com/wildfly/quickstart/
 :githubRepoBranch: master
 :guidesBaseUrl: https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/
@@ -36,9 +91,6 @@
 :SingletonSubsystemNamespace: urn:jboss:domain:singleton:1.0
 :TransactionsSubsystemNamespace: urn:jboss:domain:transactions:4.0
 
-:DocInfoProductNameURL: jboss_enterprise_application_platform_continuous_delivery
-:DocInfoProductName: JBoss Enterprise Application Platform continuous delivery
-:DocInfoProductNumber: 12
 
 // LinkProductDocHome: https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/
 :LinkProductDocHome: https://access.redhat.com/documentation/en/jboss-enterprise-application-platform-continuous-delivery

--- a/shared-doc/cd-create-project.adoc
+++ b/shared-doc/cd-create-project.adoc
@@ -1,0 +1,32 @@
+
+[[prepare_openshift_for_quickstart_deployment]]
+= Prepare OpenShift for Quickstart Deployment
+
+. Log in to your OpenShift instance using the `oc login` command.
+. Create a new project for the quickstart in OpenShift. You can create a project in OpenShift using the following command.
++
+[options="nowrap",subs="attributes"]
+----
+$ oc new-project {artifactId}-project
+----
+. Create a keystore.
++
+{xpaasproduct-shortname} requires a keystore to be imported to properly install and configure the image on your OpenShift instance.
++
+[WARNING]
+====
+The following commands generate a self-signed certificate, but for production environments Red Hat recommends that you use your own SSL certificate purchased from a verified Certificate Authority (CA) for SSL-encrypted connections (HTTPS).
+====
++
+You can use the Java `keytool` command to generate a keystore using the following command.
++
+[options="nowrap",subs="attributes"]
+----
+$ keytool -genkey -keyalg RSA -alias {artifactId}-project-selfsigned -keystore keystore.jks -validity 360 -keysize 2048
+----
+. Create a secret from the previously created keystore using the following command.
++
+[options="nowrap",subs="attributes"]
+----
+$ oc secrets new eap7-app-secret keystore.jks
+----

--- a/shared-doc/cd-deploy-project.adoc
+++ b/shared-doc/cd-deploy-project.adoc
@@ -1,0 +1,33 @@
+[[deploy_eap_s2i]]
+= Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+
+. Create a new OpenShift application using the {xpaasproduct-shortname} image and the quickstart's source code. Use the following command to use the `{ImagePrefixVersion}-basic-s2i` template with the `{artifactId}` source code on GitHub.
++
+[options="nowrap",subs="+attributes"]
+----
+oc new-app --template={ImagePrefixVersion}-basic-s2i {backslash}<1>
+ -p IMAGE_STREAM_NAMESPACE="{artifactId}-project" {backslash}<2>
+ -p SOURCE_REPOSITORY_URL="{EAPQuickStartRepo}" {backslash}<3>
+ -p SOURCE_REPOSITORY_REF="{EAPQuickStartRepoRef}" {backslash}<4>
+ -p CONTEXT_DIR="kitchensink"<5>
+----
+<1> The template to use.
+<2> The latest images streams and templates xref:import_imagestreams_templates[were imported into the project's namespace], so you must specify the namespace of where to find the image stream. This is usually the OpenShift project's name.
+<3> URL to the repository containing the application source code.
+<4> The Git repository reference to use for the source code. This can be a Git branch or tag reference.
+<5> The directory within the source repository to build.
++
+NOTE: A template can specify default values for many template parameters, and you might have to override some, or all, of the defaults. To see template information, including a list of parameters and any default values, use the command `oc describe template __TEMPLATE_NAME__`.
+
+. Retrieve the name of the build configuration.
++
+[options="nowrap"]
+----
+$ oc get bc -o name
+----
+. Use the name of the build configuration from the previous step to view the Maven progress of the build.
++
+[options="nowrap",subs="+quotes"]
+----
+$ oc logs -f buildconfig/eap-app
+----

--- a/shared-doc/cd-import-imagestreams-templates.adoc
+++ b/shared-doc/cd-import-imagestreams-templates.adoc
@@ -1,0 +1,42 @@
+
+[[import_imagestreams_templates]]
+= Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+
+Use the following command to import the latest {xpaasproduct-shortname} image streams and templates into your OpenShift project's namespace.
+
+[options="nowrap",subs="+attributes"]
+----
+for resource in \
+  {ImagePrefixVersion}-image-stream.json \
+  {ImagePrefixVersion}-amq-persistent-s2i.json \
+  {ImagePrefixVersion}-amq-s2i.json \
+  {ImagePrefixVersion}-basic-s2i.json \
+  {ImagePrefixVersion}-https-s2i.json \
+  {ImagePrefixVersion}-mongodb-persistent-s2i.json \
+  {ImagePrefixVersion}-mongodb-s2i.json \
+  {ImagePrefixVersion}-mysql-persistent-s2i.json \
+  {ImagePrefixVersion}-mysql-s2i.json \
+  {ImagePrefixVersion}-postgresql-persistent-s2i.json \
+  {ImagePrefixVersion}-postgresql-s2i.json \
+ifndef::eap-openshift-online[  {ImagePrefixVersion}-third-party-db-s2i.json \]
+ifndef::eap-openshift-online[  {ImagePrefixVersion}-tx-recovery-s2i.json \]
+  {ImagePrefixVersion}-sso-s2i.json
+do
+  oc replace --force -f \
+{ImageandTemplateImportURL}${resource}
+done
+----
+
+[NOTE]
+====
+The {ProductShortName} image streams and templates imported using the above command are only available within that OpenShift project.
+
+If you have administrative access to the general `openshift` namespace and want the image streams and templates to be accessible by all projects, add `-n openshift` to the `oc replace` line of the command. For example:
+
+[options="nowrap"]
+----
+...
+oc replace -n openshift --force -f \
+...
+----
+====

--- a/shared-doc/cd-openshift-getting-started.adoc
+++ b/shared-doc/cd-openshift-getting-started.adoc
@@ -1,0 +1,9 @@
+[[getting_started_with_openshift]]
+= Getting Started with OpenShift
+
+This document contains the basic instructions to build and deploy this quickstart to {xpaasproduct-shortname} or {xpaasproductOpenShiftOnline-shortname}.
+
+
+See link:{LinkOpenShiftGuide}[_{EapForOpenshiftBookName}_] for more detailed information about building and running applications on {xpaasproduct-shortname}.
+
+See link:{LinkOpenShiftOnlineGuide}[_{EapForOpenshiftBookName}_] for more detailed information about building and running applications on {xpaasproductOpenShiftOnline-shortname}.

--- a/shared-doc/cd-post-deployment-tasks.adoc
+++ b/shared-doc/cd-post-deployment-tasks.adoc
@@ -1,0 +1,37 @@
+[[post_deployment]]
+= OpenShift Post Deployment Tasks
+
+Depending on your application, some tasks might need to be performed after your OpenShift application has been built and deployed. This might include exposing a service so that the application is viewable from outside of OpenShift, or scaling your application to a specific number of replicas.
+
+. Get the service name of the quickstart application using the following command.
++
+[options="nowrap",subs="+quotes"]
+----
+$ oc get service
+----
+. Expose the main service as a route so you can access the application from outside of OpenShift. For example, for the `{artifactId}` quickstart, use the following command to expose the required service and port.
++
+[options="nowrap",subs="+quotes"]
+----
+$ oc expose service/__eap-app__ --port=__8080__
+----
++
+[NOTE]
+====
+If you used a template to create the application, the route might already exist. If it does, continue on to the next step.
+====
+. Get the URL of the route.
++
+[options="nowrap"]
+----
+$ oc get route
+----
+. Access the application in your web browser using the URL. The URL is the value of the `HOST/PORT` field from previous command's output.
++
+If your application does not use the {ProductShortName} root context, append the context of the application to the URL. For example, for the `kitchensink` quickstart, the URL might be `http://__HOST_PORT_VALUE__/{artifactId}/`.
+. Optionally, you can also scale up the application instance by running the following command. This increases the number of replicas to `3`.
++
+[options="nowrap",subs="+quotes"]
+----
+$ oc scale deploymentconfig eap-app --replicas=3
+----

--- a/shopping-cart/README.adoc
+++ b/shopping-cart/README.adoc
@@ -13,7 +13,7 @@ include::../shared-doc/attributes.adoc[]
 :source: {githubRepoUrl}
 
 [abstract]
-The `shopping-cart` quickstart demonstrates how to deploy and run a simple Java EE 7 shopping cart application that uses a stateful session bean (SFSB).
+The `shopping-cart` quickstart demonstrates how to deploy and run a simple {javaVersion} shopping cart application that uses a stateful session bean (SFSB).
 
 :standalone-server-type: default
 :archiveType: jar
@@ -22,7 +22,7 @@ The `shopping-cart` quickstart demonstrates how to deploy and run a simple Java 
 
 == What is it?
 
-The `shopping-cart` quickstart demonstrates how to deploy and run a simple Java EE 7 application that uses a stateful session bean (SFSB) in {productNameFull}. The application allows customers to buy, checkout, and view their cart contents.
+The `shopping-cart` quickstart demonstrates how to deploy and run a simple {javaVersion} application that uses a stateful session bean (SFSB) in {productNameFull}. The application allows customers to buy, checkout, and view their cart contents.
 
 The `shopping-cart` application consists of the following:
 

--- a/spring-kitchensink-basic/README.adoc
+++ b/spring-kitchensink-basic/README.adoc
@@ -12,14 +12,14 @@ include::../shared-doc/attributes.adoc[]
 :source: {githubRepoUrl}
 
 [abstract]
-The `spring-kitchensink-basic` quickstart is an example of a Java EE 7 application using JSP, JPA and Spring 4.x.
+The `spring-kitchensink-basic` quickstart is an example of a {javaVersion} application using JSP, JPA and Spring 4.x.
 
 :standalone-server-type: default
 :archiveType: war
 
 == What is it?
 
-The `spring-kitchensink-basic` quickstart is an example of a Java EE 7 application using JSP, JPA and Spring 4.x in {productNameFull}. It
+The `spring-kitchensink-basic` quickstart is an example of a {javaVersion} application using JSP, JPA and Spring 4.x in {productNameFull}. It
 includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java:
 
 * In the `jboss-as-spring-mvc-context.xml` file, the `context:component-scan`

--- a/thread-racing/README.adoc
+++ b/thread-racing/README.adoc
@@ -20,11 +20,11 @@ A thread racing web application that demonstrates technologies introduced or upd
 
 == What is it?
 
-The `thread-racing` quickstart is a web application that demonstrates new and updated technologies introduced by the Java EE 7 specification through simple use cases.
+The `thread-racing` quickstart is a web application that demonstrates new and updated technologies introduced by the {javaVersion} specification through simple use cases.
 
 The web application allows the user to trigger a race between 4 threads and follow, in real time, the progress of each thread until the race ends.
 
-The race itself consists of multiple stages, each demonstrating the usage of a specific new or updated Java EE 7 technology:
+The race itself consists of multiple stages, each demonstrating the usage of a specific new or updated {javaVersion} technology:
 
 * Batch 1.0
 * EE Concurrency 1.0
@@ -32,7 +32,7 @@ The race itself consists of multiple stages, each demonstrating the usage of a s
 * JMS 2.0
 * JSON 1.0
 
-WebSockets 1.0 is one of the most relevant new technologies introduced by Java EE 7. Instead of being used in a race stage, a WebSockets 1.0 ServerEndpoint provides the remote application interface.
+WebSockets 1.0 is one of the most relevant new technologies introduced by {javaVersion}. Instead of being used in a race stage, a WebSockets 1.0 ServerEndpoint provides the remote application interface.
 A new race is run when a client establishes a session. That session is then used to update the client in real time, with respect to the race progress and results. The `src/main/java/org/jboss/as/quickstarts/threadracing/WebSocketRace.java` file is the WebSocket server endpoint class and is a good entry point when studying how the application code works.
 
 JPA 2.1 is also present in the application code. Specifically it is used to store race results in the default data source instance, which is also new to Java EE. Further details are included in the `src/main/java/org/jboss/as/quickstarts/threadracing/results/RaceResults.java` class.

--- a/websocket-hello/README.adoc
+++ b/websocket-hello/README.adoc
@@ -25,7 +25,7 @@ The `websocket-hello` quickstart demonstrates how to create a simple WebSocket-e
 * A WebSocket server endpoint that uses annotations to interact with the WebSocket events.
 * A `jboss-web.xml` file configured to enable WebSockets
 
-WebSockets are a requirement of the Java EE 7 specification and are implemented in {productName} {productVersion}. They are configured in the `undertow` subsystem of the server configuration file. This quickstart uses the WebSocket default settings, so it is not necessary to modify the server configuration to deploy and run this quickstart.
+WebSockets are a requirement of the {javaVersion} specification and are implemented in {productName} {productVersion}. They are configured in the `undertow` subsystem of the server configuration file. This quickstart uses the WebSocket default settings, so it is not necessary to modify the server configuration to deploy and run this quickstart.
 
 NOTE: This quickstart demonstrates only a few of the basic functions. A fully functional application should provide better error handling and intercept and handle additional events.
 

--- a/wicket-ear/README.adoc
+++ b/wicket-ear/README.adoc
@@ -16,7 +16,7 @@ Demonstrates how to use the Wicket Framework 7.x with the JBoss server using the
 
 == What is it?
 
-This is an example of how to use Wicket Framework 7.x with WildFly, leveraging features of Java EE 7, using the Wicket Java EE integration.
+This is an example of how to use Wicket Framework 7.x with WildFly, leveraging features of {javaVersion}, using the Wicket Java EE integration.
 
 Features used:
 

--- a/wicket-war/README.adoc
+++ b/wicket-war/README.adoc
@@ -16,7 +16,7 @@ Demonstrates how to use the Wicket Framework 7.x with the JBoss server using the
 
 == What is it?
 
-This is an example of how to use Wicket Framework 7.x with WildFly, leveraging features of Java EE 7, using the Wicket-Stuff Java EE integration.
+This is an example of how to use Wicket Framework 7.x with WildFly, leveraging features of {javaVersion}, using the Wicket-Stuff Java EE integration.
 
 Features used:
 


### PR DESCRIPTION
@emmartins : 

Please do not merge this yet! This is only so you can see what my plan is going forward. These changes are currently only done for the kitchensink README.adoc file. Once Tomas Remes approves the instructions, I will apply the changes to all of the other quickstart README files.

If you want to test this, first build the kitchensink README to see the 7.x instructions.
Then comment out the `:EAPCDRelease:` attribute in the shared-doc/attributes.adoc file and build the README again to see the CD instructions.

