### PR TITLE
First cut at updating README files to support CD.x and 7.x releases

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,13 +1,9 @@
-= {productNameFull} ({productName}) Quickstarts
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:ext-relative: {outfilesuffix}
 include::shared-doc/attributes.adoc[]
 
+= {productNameFull} ({productName}) Quickstarts
+
 [abstract]
-The quickstarts demonstrate Java EE 7 and a few additional technologies from the JBoss stack. They provide small, specific, working examples that can be used as a reference for your own project.
+The quickstarts demonstrate {javaVersion} and a few additional technologies from the JBoss stack. They provide small, specific, working examples that can be used as a reference for your own project.
 
 [[introduction]]
 == Introduction
@@ -40,21 +36,21 @@ The quickstart `README` files use the _replaceable_ value `__{jbossHomeName}__` 
 [[available_quickstarts]]
 == Available Quickstarts
 
-All available quickstarts can be found here: https://developers.redhat.com/quickstarts/eap/. You can review the technologies demonstrated by the quickstart. You can also view the required experience level. Click on the quickstart to see more detailed information about how to run it. Some quickstarts require deployment of other quickstarts. This information is noted in the `Prerequisites` section of the quickstart `README` file.
+All available quickstarts can be found here: {githubRepoUrl}. You can review the technologies demonstrated by the quickstart. You can also view the required experience level. Click on the quickstart to see more detailed information about how to run it. Some quickstarts require deployment of other quickstarts. This information is noted in the `Prerequisites` section of the quickstart `README` file.
 
 NOTE: Some of these quickstarts use the H2 database included with {productName}. It is a lightweight, relational example datasource that is used for examples only. It is not robust or scalable, is not supported, and should NOT be used in a production environment!
 
 //<TOC>
 [cols="1,1,2,1,1", options="header"]
 |===
-| Quickstart Name | Demonstrated Technologies | Description | Experience Level Required | Prerequisites
+| Quickstart Name | Demonstrated Technologies | Description | Experience Level Required | Prerequisites 
 | link:app-client/README{outfilesuffix}[app-client]|EJB, EAR, AppClient | The `app-client` quickstart demonstrates how to code and package a client app and use the {productName} client container to start the client `Main` program. | Intermediate | _none_
 | link:batch-processing/README{outfilesuffix}[batch-processing]|CDI, Batch 1.0, JSF | The `batch-processing` quickstart shows how to use chunk oriented batch jobs to import a file to a database. | Intermediate | _none_
 | link:bean-validation/README{outfilesuffix}[bean-validation]|CDI, JPA, BV | The `bean-validation` quickstart provides Arquillian tests to demonstrate how to use CDI, JPA, and Bean Validation. | Beginner | _none_
 | link:bean-validation-custom-constraint/README{outfilesuffix}[bean-validation-custom-constraint]|CDI, JPA, BV | The `bean-validation-custom-constraint` quickstart demonstrates how to use the Bean Validation API to define custom constraints and validators. | Beginner | _none_
 | link:bmt/README{outfilesuffix}[bmt]|EJB, BMT | The `bmt` quickstart demonstrates Bean-Managed Transactions (BMT), showing how to manually manage transaction demarcation while accessing JPA entities. | Intermediate | _none_
 | link:cmt/README{outfilesuffix}[cmt]|EJB, CMT, JMS | The `cmt` quickstart demonstrates Container-Managed Transactions (CMT), showing how to use transactions managed by the container. | Intermediate | _none_
-| link:contacts-jquerymobile/README{outfilesuffix}[contacts-jquerymobile]|jQuery Mobile, jQuery, JavaScript, HTML5, REST | The `contacts-jquerymobile` quickstart demonstrates a Java EE 7 mobile database application using HTML5, jQuery Mobile, JAX-RS, JPA, and REST. | Beginner | _none_
+| link:contacts-jquerymobile/README{outfilesuffix}[contacts-jquerymobile]|jQuery Mobile, jQuery, JavaScript, HTML5, REST | The `contacts-jquerymobile` quickstart demonstrates a {javaVersion} mobile database application using HTML5, jQuery Mobile, JAX-RS, JPA, and REST. | Beginner | _none_
 | link:deltaspike-authorization/README{outfilesuffix}[deltaspike-authorization]|JSF, CDI, Deltaspike | Demonstrate the creation of a custom authorization example using @SecurityBindingType from DeltaSpike | Beginner | _none_
 | link:deltaspike-beanbuilder/README{outfilesuffix}[deltaspike-beanbuilder]|CDI, DeltaSpike | Shows how to create new beans using DeltaSpike utilities. | Advanced | _none_
 | link:deltaspike-projectstage/README{outfilesuffix}[deltaspike-projectstage]|JSF, CDI, Deltaspike | Demonstrate usage of DeltaSpike project stage and shows usage of a conditional @Exclude | Beginner | _none_
@@ -81,7 +77,7 @@ NOTE: Some of these quickstarts use the H2 database included with {productName}.
 | link:helloworld-mdb-propertysubstitution/README{outfilesuffix}[helloworld-mdb-propertysubstitution]|JMS, EJB, MDB | The `helloworld-mdb-propertysubstitution` quickstart demonstrates the use of JMS and EJB MDB, enabling property substitution with annotations. | Intermediate | _none_
 | link:helloworld-mutual-ssl/README{outfilesuffix}[helloworld-mutual-ssl]|Mutual SSL, Undertow | The `helloworld-mutual-ssl` quickstart is a basic example that demonstrates mutual SSL configuration in {productName} | Intermediate | _none_
 | link:helloworld-mutual-ssl-secured/README{outfilesuffix}[helloworld-mutual-ssl-secured]|Mutual SSL, Security, Undertow | The `helloworld-mutual-ssl-secured` quickstart demonstrates securing a Web application using client mutual SSL authentication and role-based access control | Intermediate | _none_
-| link:helloworld-rf/README{outfilesuffix}[helloworld-rf]|CDI, JSF, RichFaces | Similar to the helloworld quickstart, but with a JSF front end | Beginner | _none_
+| link:helloworld-rf/README{outfilesuffix}[helloworld-rf]|CDI, JSF, RichFaces | Similar to the helloworld quickstart, but with a JSF front end. | Beginner | _none_
 | link:helloworld-rs/README{outfilesuffix}[helloworld-rs]|CDI, JAX-RS | The `helloworld-rs` quickstart demonstrates a simple Hello World application, bundled and deployed as a WAR, that uses JAX-RS to say Hello. | Intermediate | _none_
 | link:helloworld-singleton/README{outfilesuffix}[helloworld-singleton]|EJB, Singleton | The `helloworld-singleton` quickstart demonstrates an EJB Singleton Bean that is instantiated once and maintains state for the life of the session. | Beginner | _none_
 | link:helloworld-ssl/README{outfilesuffix}[helloworld-ssl]|SSL, Undertow | The `helloworld-ssl` quickstart is a basic example that demonstrates server side SSL configuration in {productName}. | Beginner | _none_
@@ -100,11 +96,11 @@ NOTE: Some of these quickstarts use the H2 database included with {productName}.
 | link:jta-crash-rec/README{outfilesuffix}[jta-crash-rec]|JTA, Crash Recovery | The `jta-crash-rec` quickstart uses JTA and Byteman to show how to code distributed (XA) transactions in order to preserve ACID properties on server crash. | Advanced | _none_
 | link:jts/README{outfilesuffix}[jts]|JTS, EJB, JMS | The `jts` quickstart shows how to use JTS to perform distributed transactions across multiple containers, fulfilling the properties of an ACID transaction. | Intermediate | link:cmt/README{outfilesuffix}[cmt]
 | link:jts-distributed-crash-rec/README{outfilesuffix}[jts-distributed-crash-rec]|JTS, Crash Recovery | The `jts-distributed-crash-rec` quickstart uses JTS and Byteman to demonstrate distributed crash recovery across multiple application servers. | Advanced | link:jts/README{outfilesuffix}[jts]
-| link:kitchensink/README{outfilesuffix}[kitchensink]|CDI, JSF, JPA, EJB, JAX-RS, BV | The `kitchensink` quickstart demonstrates a Java EE 7 web-enabled database application using JSF, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
-| link:kitchensink-angularjs/README{outfilesuffix}[kitchensink-angularjs]|AngularJS, CDI, JPA, EJB, JPA, JAX-RS, BV | The `kitchensink-angularjs` quickstart demonstrates a Java EE 7 application using AngularJS with JAX-RS, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
+| link:kitchensink/README{outfilesuffix}[kitchensink]|CDI, JSF, JPA, EJB, JAX-RS, BV | The `kitchensink` quickstart demonstrates a {javaVersion} web-enabled database application using JSF, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
+| link:kitchensink-angularjs/README{outfilesuffix}[kitchensink-angularjs]|AngularJS, CDI, JPA, EJB, JPA, JAX-RS, BV | The `kitchensink-angularjs` quickstart demonstrates a {javaVersion} application using AngularJS with JAX-RS, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
 | link:kitchensink-ear/README{outfilesuffix}[kitchensink-ear]|CDI, JSF, JPA, EJB, JAX-RS, BV, EAR | The `kitchensink-ear` quickstart demonstrates web-enabled database application, using JSF, CDI, EJB, JPA, and Bean Validation, packaged as an EAR. | Intermediate | _none_
 | link:kitchensink-jsp/README{outfilesuffix}[kitchensink-jsp]|JSP, JSTL, CDI, JPA, EJB, JAX-RS, BV | The `kitchensink-jsp` quickstart demonstrates how to use JSP, JSTL, CDI, EJB, JPA, and Bean Validation in {productName}. | Intermediate | _none_
-| link:kitchensink-ml/README{outfilesuffix}[kitchensink-ml]|CDI, JSF, JPA, EJB, JAX-RS, BV, i18n, l10n | The `kitchensink-ml` quickstart demonstrates a localized Java EE 7 compliant application using JSF, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
+| link:kitchensink-ml/README{outfilesuffix}[kitchensink-ml]|CDI, JSF, JPA, EJB, JAX-RS, BV, i18n, l10n | The `kitchensink-ml` quickstart demonstrates a localized {javaVersion} compliant application using JSF, CDI, EJB, JPA, and Bean Validation. | Intermediate | _none_
 | link:kitchensink-utjs-angularjs/README{outfilesuffix}[kitchensink-utjs-angularjs]|Undertow.js, Angular.js | Based on kitchensink, but uses a Angular for the front end and Undertow.js for the back end. | Intermediate | _none_
 | link:kitchensink-utjs-mustache/README{outfilesuffix}[kitchensink-utjs-mustache]|Undertow.js, Mustache | Based on kitchensink, but uses Mustache for the front end and Undertow.js for the back end. | Intermediate | _none_
 | link:logging/README{outfilesuffix}[logging]|Logging | The `logging` quickstart demonstrates how to configure different logging levels in {productName}. It also includes an asynchronous logging example. | Intermediate | _none_
@@ -120,9 +116,9 @@ NOTE: Some of these quickstarts use the H2 database included with {productName}.
 | link:servlet-async/README{outfilesuffix}[servlet-async]|Asynchronous Servlet, CDI, EJB | The `servlet-async` quickstart demonstrates how to use asynchronous servlets to detach long-running tasks and free up the request processing thread. | Intermediate | _none_
 | link:servlet-filterlistener/README{outfilesuffix}[servlet-filterlistener]|Servlet Filter, Servlet Listener | The `servlet-filterlistener` quickstart demonstrates how to use Servlet filters and listeners in an application. | Intermediate | _none_
 | link:servlet-security/README{outfilesuffix}[servlet-security]|Servlet, Security | The `servlet-security` quickstart demonstrates the use of Java EE declarative security to control access to Servlets and Security in {productName}. | Intermediate | _none_
-| link:shopping-cart/README{outfilesuffix}[shopping-cart]|SFSB EJB | The `shopping-cart` quickstart demonstrates how to deploy and run a simple Java EE 7 shopping cart application that uses a stateful session bean (SFSB). | Intermediate | _none_
+| link:shopping-cart/README{outfilesuffix}[shopping-cart]|SFSB EJB | The `shopping-cart` quickstart demonstrates how to deploy and run a simple {javaVersion} shopping cart application that uses a stateful session bean (SFSB). | Intermediate | _none_
 | link:spring-greeter/README{outfilesuffix}[spring-greeter]|Spring MVC, JSP, JPA | The `spring-greeter` quickstart is based on the `greeter` quickstart, but differs in that it uses Spring MVC for Mapping `GET` and `POST` requests. | Beginner | _none_
-| link:spring-kitchensink-basic/README{outfilesuffix}[spring-kitchensink-basic]|JSP, JPA, JSON, Spring, JUnit | The `spring-kitchensink-basic` quickstart is an example of a Java EE 7 application using JSP, JPA and Spring 4.x. | Intermediate | _none_
+| link:spring-kitchensink-basic/README{outfilesuffix}[spring-kitchensink-basic]|JSP, JPA, JSON, Spring, JUnit | The `spring-kitchensink-basic` quickstart is an example of a {javaVersion} application using JSP, JPA and Spring 4.x. | Intermediate | _none_
 | link:spring-kitchensink-springmvctest/README{outfilesuffix}[spring-kitchensink-springmvctest]|JSP, JPA, JSON, Spring, JUnit | The  `spring-kitchensink-springmvctest` quickstart demonstrates how to create an MVC application using JSP, JPA and Spring 4.x. | Intermediate | _none_
 | link:spring-resteasy/README{outfilesuffix}[spring-resteasy]|Resteasy, Spring | The `spring-resteasy` quickstart demonstrates how to package and deploy a web application that includes resteasy-spring integration. | Beginner | _none_
 | link:tasks-jsf/README{outfilesuffix}[tasks-jsf]|JSF, JPA | The `tasks-jsf` quickstart demonstrates how to use JPA persistence with JSF as the view layer. | Intermediate | link:tasks/README{outfilesuffix}[tasks]

--- a/app-client/README.adoc
+++ b/app-client/README.adoc
@@ -1,15 +1,10 @@
-= app-client: Use the {productName} Application Client Container
-:author: Wolf-Dieter Fink
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= app-client: Use the {productName} Application Client Container
+
+:author: Wolf-Dieter Fink
 :level: Intermediate
 :technologies: EJB, EAR, AppClient
-:source: {githubRepoUrl}
 
 [abstract]
 The `app-client` quickstart demonstrates how to code and package a client app and use the {productName} client container to start the client `Main` program.
@@ -40,37 +35,16 @@ This example consists of the following Maven projects, each with a shared parent
 
 The root `pom.xml` file builds each of the subprojects in the appropriate order.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*****************************************************
 // Add the Authorized Application and Management Users
-//*****************************************************
-// ==  Add the Authorized Application and Management Users
 include::../shared-doc/add-application-and-management-users.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the Server
-//include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
+// Start the Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart EAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Remote Client Application from the Same Machine
 

--- a/batch-processing/README.adoc
+++ b/batch-processing/README.adoc
@@ -1,21 +1,22 @@
-= batch-processing: Chunk oriented Batch 1.0 processing
-:author: Rafael Benevides
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= batch-processing: Chunk oriented Batch 1.0 processing
+
+:author: Rafael Benevides
 :level: Intermediate
 :technologies: CDI, Batch 1.0, JSF
-:source: {githubRepoUrl}
 
 [abstract]
 The `batch-processing` quickstart shows how to use chunk oriented batch jobs to import a file to a database.
 
 :standalone-server-type: default
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -35,35 +36,20 @@ The job contains two tasks:
 The database schema defines that the column for name is unique. For that reason, any attempt to persist a duplicate value will throw an exception. On the second attempt to run the job, the `ChunkCheckpoint` provides information to skip the contacts that were already persisted.
 
 //*************************************************
-// Add notes about use in a production environment.
+// Product Release content only
 //*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
+
+ifndef::EAPCDRelease[]
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -166,26 +152,31 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/bean-validation-custom-constraint/README.adoc
+++ b/bean-validation-custom-constraint/README.adoc
@@ -1,21 +1,17 @@
-= bean-validation-custom-constraint: Bean Validation Using Custom Constraints
-:author: Giriraj Sharma
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= bean-validation-custom-constraint: Bean Validation Using Custom Constraints
+:author: Giriraj Sharma
 :level: Beginner
 :technologies: CDI, JPA, BV
-:source: {githubRepoUrl}
 
 [abstract]
 The `bean-validation-custom-constraint` quickstart demonstrates how to use the Bean Validation API to define custom constraints and validators.
 
 :standalone-server-type: default
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
 
 == What is it
 
@@ -23,37 +19,15 @@ The `bean-validation-custom-constraint` quickstart demonstrates how to use CDI, 
 
 This quickstart does not contain a user interface layer. The purpose of this project is to show you how to test bean validation using custom constraints with Arquillian. In this quickstart, the personAddress field of entity Person is validated using a set of custom constraints defined in the class AddressValidator. If you want to see an example of how to test bean validation with a user interface, look at the link:../kitchensink/README{outfilesuffix}[kitchensink] example.
 
-//*************************************************
-// Add notes about use in a production environment.
-//*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
 
 == Investigate the Console Output
@@ -88,16 +62,9 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
 
 // Additional debugging information

--- a/bean-validation/README.adoc
+++ b/bean-validation/README.adoc
@@ -1,21 +1,17 @@
-= bean-validation: Bean Validation Tested Using Arquillian
-:author: Karel Piwko
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= bean-validation: Bean Validation Tested Using Arquillian
+:author: Karel Piwko
 :level: Beginner
 :technologies: CDI, JPA, BV
-:source: {githubRepoUrl}
 
 [abstract]
 The `bean-validation` quickstart provides Arquillian tests to demonstrate how to use CDI, JPA, and Bean Validation.
 
 :standalone-server-type: default
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
 
 == What is it?
 
@@ -25,38 +21,16 @@ This quickstart does not contain a user interface layer. The purpose of this pro
 
 This quickstart is a basic example of bean validation and is not localized. Because it is not localized, English messages are hard-coded in the constraint annotations in the `Member` class to ensure the test violation messages are matched when running the {productName} server using another language. For examples of localized quickstarts, see the link:../kitchensink-ml/README{outfilesuffix}[kitchensink-ml] and link:../logging-tools/README{outfilesuffix}[logging-tools] quickstarts.
 
-//*************************************************
-// Add notes about use in a production environment.
-//*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
 
 == Investigate the Console Output
 
@@ -90,14 +64,7 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/bmt/README.adoc
+++ b/bmt/README.adoc
@@ -1,21 +1,22 @@
-= bmt: Bean Managed Transactions with JPA and JTA
-:author: Mike Musgrove
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= bmt: Bean Managed Transactions with JPA and JTA
+:author: Mike Musgrove
 :level: Intermediate
 :technologies: EJB, BMT
-:source: {githubRepoUrl}
 
 [abstract]
 The `bmt` quickstart demonstrates Bean-Managed Transactions (BMT), showing how to manually manage transaction demarcation while accessing JPA entities.
 
 :standalone-server-type: default
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
+:performance-scalability:
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -31,36 +32,20 @@ When you run this example, you are presented with a *Use bean managed Entity Man
 This example shows how to transactionally insert key value pairs into the database and demonstrates the requirements on the developer with respect to the JPA Entity Manager.
 
 //*************************************************
-// Add notes about use in a production environment.
+// Product Release content only
 //*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
-:performance-scalability:
+
+ifndef::EAPCDRelease[]
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -83,27 +68,31 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/cmt/README.adoc
+++ b/cmt/README.adoc
@@ -1,21 +1,17 @@
-= cmt: Container Managed Transactions (CMT)
-:author: Tom Jenkinson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= cmt: Container Managed Transactions (CMT)
+:author: Tom Jenkinson
 :level: Intermediate
 :technologies: EJB, CMT, JMS
-:source: {githubRepoUrl}
 
 [abstract]
 The `cmt` quickstart demonstrates Container-Managed Transactions (CMT), showing how to use transactions managed by the container.
 
 :standalone-server-type: full
 :archiveType: war
+:uses-h2:
+
 
 == What is it?
 
@@ -51,35 +47,21 @@ NotSupported:: If there is a transaction running, it will be suspended and no tr
 Supports:: This will run the method within a transaction if a transaction exists, alternatively, if there is no transaction running, the method will not be executed within the scope of a transaction.
 Never:: If the client has a transaction running and does not suspend it but calls a method annotated with Never then an EJB exception will be raised.
 
-//***************************************
-// Add notes about use in a production environment.
-//***************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
+//*************************************************
+// Product Release content only
+//*************************************************
+
+ifndef::EAPCDRelease[]
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the full profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server (with the full profile)
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -106,30 +88,36 @@ You will see the following warnings in the server log. You can ignore these warn
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
 NOTE: Within JBoss Developer Studio, make sure you define a server runtime environment that uses the `standalone-full.xml` configuration file.
 
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
+// Debug the Application
+include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
 
 //*************************************************
-// Add info to debug the application
+// CD Release content only
 //*************************************************
-// == Debug the Application
-include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+
+

--- a/contacts-jquerymobile/README.adoc
+++ b/contacts-jquerymobile/README.adoc
@@ -1,25 +1,23 @@
-= contacts-jquerymobile: CRUD Example Using HTML5, jQuery Mobile and JAX-RS
-:author: Joshua Wilson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= contacts-jquerymobile: CRUD Example Using HTML5, jQuery Mobile and JAX-RS
+:author: Joshua Wilson
 :level: Beginner
 :technologies: jQuery Mobile, jQuery, JavaScript, HTML5, REST
-:source: {githubRepoUrl}
 
 [abstract]
-The `contacts-jquerymobile` quickstart demonstrates a Java EE 7 mobile database application using HTML5, jQuery Mobile, JAX-RS, JPA, and REST.
+The `contacts-jquerymobile` quickstart demonstrates a {javaVersion} mobile database application using HTML5, jQuery Mobile, JAX-RS, JPA, and REST.
 
 :standalone-server-type: default
 :archiveType: war
 
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
+
 == What is it?
 
-The `contact-jquerymobile` quickstart is a deployable Maven 3 project designed to help you get your foot in the door developing HTML5 based mobile web applications with Java EE 7 in {productNameFull}. This project is setup to allow you to create a basic Java EE 7 application using HTML5, jQuery Mobile, JAX-RS, CDI, EJB, JPA, and Bean Validation. It includes a persistence unit and some sample persistence and transaction code to help you get your feet wet with database access in enterprise Java.
+The `contact-jquerymobile` quickstart is a deployable Maven 3 project designed to help you get your foot in the door developing HTML5 based mobile web applications with {javaVersion} in {productNameFull}. This project is setup to allow you to create a basic {javaVersion} application using HTML5, jQuery Mobile, JAX-RS, CDI, EJB, JPA, and Bean Validation. It includes a persistence unit and some sample persistence and transaction code to help you get your feet wet with database access in enterprise Java.
 
 This application is built using a HTML5 + REST approach. This uses a pure HTML client that interacts with with the application server via restful end-points (JAX-RS). This application also uses some of the latest HTML5 features and advanced JAX-RS. And since testing is just as important with client side as it is server side, this application uses QUnit to show you how to unit test your JavaScript.
 
@@ -36,9 +34,12 @@ This application focuses on *CRUD* in a strictly mobile app using only *jQuery M
 Validation is an important part of an application. Typically in an HTML5 app you can let the built-in HTML5 form validation do the work for you. However, mobile browsers do not support this feature at this time. In order to validate the forms, the `jquery.validate` plugin was added, which provides both client-side and server-side validation. Over AJAX, if there is an error, the error is returned and displayed in the form. You can see an example of this in the *Edit* form if you enter an email that is already in use. The application will attempt to insert the error message into a field if that field exists. If the field does not exist then it display it at the top. In addition, there are xref:run_the_qunit_tests[QUnit Tests] for every form of validation.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 
 // Additional system requirements for this quickstart:
@@ -48,23 +49,12 @@ Mobile web support is limited to Android and iOS devices. It should run on HP, a
 
 With the prerequisites out of the way, you are ready to build and deploy.
 
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 :mobileApp:
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -104,10 +94,7 @@ The application is made up of the following pages:
 * Same as *Add form*.
 * *Delete* button will delete the contact currently viewed and return you to the Main page.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
 
@@ -137,10 +124,7 @@ $ mvn clean package wildfly:deploy -Pminify
 $ mvn clean verify wildfly:deploy -Pminify,arq-remote
 ----
 
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
 
 
@@ -155,23 +139,10 @@ NOTE: If you use *Chrome*, some date tests fail. These are false failures and ar
 
 For more information on QUnit tests, see http://qunitjs.com/.
 
-//*************************************************
-// Run the Arquillian functional tests
-//*************************************************
-// == Run the Arquillian Functional Tests
+// Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
 
 == Debug the Application
 
@@ -183,3 +154,24 @@ either of the following two commands to pull them into your local repository. Th
 $ mvn dependency:sources
 $ mvn dependency:resolve -Dclassifier=javadoc
 ----
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/deltaspike-authorization/README.adoc
+++ b/deltaspike-authorization/README.adoc
@@ -1,15 +1,9 @@
-= deltaspike-authorization: Demonstrate the creation of a custom authorization example using @SecurityBindingType from DeltaSpike
-:author: Rafael Benevides
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= deltaspike-authorization: Demonstrate the creation of a custom authorization example using @SecurityBindingType from DeltaSpike
+:author: Rafael Benevides
 :level: Beginner
 :technologies: JSF, CDI, Deltaspike
-:source: {githubRepoUrl}
 
 [abstract]
 Demonstrate the creation of a custom authorization example using @SecurityBindingType from DeltaSpike
@@ -27,76 +21,32 @@ In this quickstart the `Authorizer` we delegate authentication to JAAS, but othe
 
 Methods on the `Controller` bean have been restricted using the security binding types.
 
-== System requirements
+// System Requirements
+include::../shared-doc/system-requirements.adoc[leveloffset=+1]
+// Use of {jbossHomeName}
+include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
+// Add the Authorized Application and Management Users
+include::../shared-doc/add-application-user.adoc[leveloffset=+1]
+// Start the Server
+include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
+// Build and Deploy the Quickstart
+include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
-All you need to build this project is Java 8.0 (Java SDK 1.8) or better, Maven 3.1 or better.
-
-The application this project produces is designed to be run on WildFly 10.
-
-== Configure Maven
-
-If you have not yet done so, you must link:../README.md#mavenconfiguration[Configure Maven] before testing the quickstarts.
-
-== Add an Application User
-
-This quickstart uses secured management interfaces and requires that you create an application user to access the running application. Instructions to set up the quickstart application user can be found here: link:../README.md#addapplicationuser[Add an Application User]
-
-== Start WildFly 10
-
-. Open a command line and navigate to the root of the JBoss server directory.
-. 
-
-The following shows the command line to start the server with the web profile:
-
-[source]
-----
-For Linux:   JBOSS_HOME/bin/standalone.sh
-For Windows: JBOSS_HOME\bin\standalone.bat
-----
-
-== Build and Deploy the Quickstart
-
-_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See link:../README.md#buildanddeploy[Build and Deploy the Quickstarts] for complete instructions and additional options._
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-Type this command to build and deploy the archive:
-
-[source]
-----
-mvn clean package wildfly:deploy
-----
-
-. This will deploy `target/wildfly-as-deltaspike-authorization.war` to the running instance of the server.
 
 == Access the application
 
-You can access the running application in a browser at the following URL: &lt;localhost:8080/wildfly-deltaspike-authorization/&gt;
+The application will be running at the following URL: http://localhost:8080/{artifactId}/.
 
-When you access the application you are redirected to a login form, already filled in with the details of the application user you set up above. Once you have logged into the application you see a page showing your username and two buttons. 
+When you access the application you are redirected to a login form, already filled in with the details of the application user you set up above. Once you have logged into the application you see a page showing your username and two buttons.
 
 When you click on the `Employee Method` button you will see the following message: `You executed a @EmployeeAllowed method` - you are authorized to invoke this method.
 
-When you click on the `Admin Method` button you will be redirected to a error page with the following exception: `org.apache.deltaspike.security.api.authorization.AccessDeniedException` - you aren't authorized to invole thos method.
+When you click on the `Admin Method` button, you are redirected to an error page with the following exception: `org.apache.deltaspike.security.api.authorization.AccessDeniedException` because you aren't authorized to invoke this method.
 
-== Undeploy the Archive
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-When you are finished testing, type this command to undeploy the archive:
-
-[source]
-----
-mvn wildfly:undeploy
-----
-
-== Run the Quickstart in JBoss Developer Studio or Eclipse
-
-You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see link:../README.md#useeclipse[Use JBoss Developer Studio or Eclipse to Run the Quickstarts] 
+// Undeploy the Quickstart
+include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application
 

--- a/deltaspike-beanbuilder/README.adoc
+++ b/deltaspike-beanbuilder/README.adoc
@@ -1,15 +1,9 @@
-= deltaspike-beanbuilder: Shows how to create new beans using DeltaSpike utilities
-:author: Rafael Benevides
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= deltaspike-beanbuilder: Shows how to create new beans using DeltaSpike utilities
+:author: Rafael Benevides
 :level: Advanced
 :technologies: CDI, DeltaSpike
-:source: {githubRepoUrl}
 
 [abstract]
 Shows how to create new beans using DeltaSpike utilities.
@@ -18,62 +12,29 @@ Shows how to create new beans using DeltaSpike utilities.
 
 This project demonstrates a CDI Portable Extension that uses DeltaSpike utilities to create new Beans.
 
-This extension permits the injection of JPA entities by id, without the need to query it. To achieve this, the extension observes the `ProcessInjectionTarget` event and get locates all the injection points that have requested injection by id. In `AfterBeanDiscovery` event, the extension creates `Bean` instances using the `BeanBuilder` utility. 
+This extension permits the injection of JPA entities by id, without the need to query it. To achieve this, the extension observes the `ProcessInjectionTarget` event and get locates all the injection points that have requested injection by id. In `AfterBeanDiscovery` event, the extension creates `Bean` instances using the `BeanBuilder` utility.
 
 The project contains a very simple JPA entity class, the extension class, the service registration file for that extension and an Arquillian test to verify the extension is working correctly.
 
 It does not contain any user interface; the tests must be run to verify everything is working correctly.
 
-== System requirements
+// System Requirements
+include::../shared-doc/system-requirements.adoc[leveloffset=+1]
+// Use of {jbossHomeName}
+include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
+// Start the Server
+include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
+//  Run the Arquillian Tests
+include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
 
-All you need to build this project is Java 8 (Java SDK 1.8) or better, Maven 3.1 or better.
 
-The application this project produces is designed to be run on WildFly 10.
+== Run the Tests in Red Hat JBoss Developer Studio or Eclipse
 
-== Configure Maven
+To run the tests in JBoss Developer Studio, first set the active Maven profile in the project properties to be either `arq-jbossas-managed`, for running on a managed server, or `arq-jbossas-remote`, for running on remote server.
 
-If you have not yet done so, you must link:../README.md#mavenconfiguration[Configure Maven] before testing the quickstarts.
-
-== Start WildFly 10 with the Web Profile
-
-. Open a command line and navigate to the root of the JBoss server directory.
-. 
-
-The following shows the command line to start the server with the web profile:
-
-[source]
-----
-For Linux:   JBOSS_HOME/bin/standalone.sh
-For Windows: JBOSS_HOME\bin\standalone.bat
-----
-
-== Run the Arquillian Tests
-
-This quickstart provides Arquillian tests. By default, these tests are configured to be skipped as Arquillian tests require the use of a container.
-
-_NOTE: The following commands assume you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See link:../README.md#arquilliantests[Run the Arquillian Tests] for complete instructions and additional options._
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-Type the following command to run the test goal with the following profile activated:
-
-[source]
-----
-mvn clean test -Parq-jbossas-remote
-----
-
-== Run tests from JBDS
-
-To be able to run the tests from JBDS, first set the active Maven profile in project properties to be either 'arq-jbossas-managed' for running on
-managed server or 'arq-jbossas-remote' for running on remote server.
-
-To run the tests, right click on the project or individual classes and select Run As –&gt; JUnit Test in the context menu.
+To run the tests, right click on the project or individual classes and select *Run As* –&gt; *JUnit Test* in the context menu.
 
 == Investigate the Console Output
-
-=== Maven
 
 Maven prints summary of performed tests into the console:
 
@@ -92,9 +53,8 @@ Results :
 Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
 ----
 
-== Run the Quickstart in JBoss Developer Studio or Eclipse
-
-You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see link:../README.md#useeclipse[Use JBoss Developer Studio or Eclipse to Run the Quickstarts]
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application
 

--- a/deltaspike-projectstage/README.adoc
+++ b/deltaspike-projectstage/README.adoc
@@ -1,15 +1,9 @@
-= deltaspike-projectstage: Demonstrate usage of DeltaSpike project stage and shows usage of a conditional @Exclude
-:author: Rafael Benevides
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= deltaspike-projectstage: Demonstrate usage of DeltaSpike project stage and shows usage of a conditional @Exclude
+:author: Rafael Benevides
 :level: Beginner
 :technologies: JSF, CDI, Deltaspike
-:source: {githubRepoUrl}
 
 [abstract]
 Demonstrate usage of DeltaSpike project stage and shows usage of a conditional @Exclude
@@ -36,79 +30,39 @@ This project has a interface called `MyBean` that has 4 different implementation
 * MyExcludedBean - Uses the annotation `@Exclude` to exclude the implementation for all project stages.
 * NoExcludedBean - The implementation is always available because this bean does not use any annotation.
 
-== System requirements
+// System Requirements
+include::../shared-doc/system-requirements.adoc[leveloffset=+1]
+// Use of {jbossHomeName}
+include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
+// Start the Server
+include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
+//  Run the Arquillian Tests
+include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
 
-All you need to build this project is Java 8.0 (Java SDK 1.8) or better, Maven 3.1 or better.
+// Build and Deploy the Quickstart
+include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
-The application this project produces is designed to be run on WildFly 10.
+== Access the application
 
-== Configure Maven
+The application will be running at the following URL: http://localhost:8080/{artifactId}/.
 
-If you have not yet done so, you must link:../README.md#mavenconfiguration[Configure Maven] before testing the quickstarts.
+You are presented with a simple page that shows the current project stage: _Staging_. You will also see the _List of available CDI instances for MyBean_ table with two available implementations.
 
-== Start WildFly 10
-
-. Open a command line and navigate to the root of the JBoss server directory.
-. 
-
-The following shows the command line to start the server with the web profile:
-
-[source]
-----
-For Linux:   JBOSS_HOME/bin/standalone.sh
-For Windows: JBOSS_HOME\bin\standalone.bat
-----
-
-== Build and Deploy the Quickstart
-
-_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See link:../README.md#buildanddeploy[Build and Deploy the Quickstarts] for complete instructions and additional options._
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-Type this command to build and deploy the archive:
+Edit the file `src/main/resources/META-INF/apache-deltaspike.properties` and change the `org.apache.deltaspike.ProjectStage` property to `Development`. Deploy the application again
 
 [source]
 ----
 mvn clean package wildfly:deploy
 ----
 
-. This will deploy `target/wildfly-as-deltaspike-projectstage.war` to the running instance of the server.
-
-== Access the application
-
-Access the running application in a browser at the following URL: http://localhost:8080/wildfly-deltaspike-projectstage[http://localhost:8080/wildfly-deltaspike-projectstage]
-
-You be presented with a simple page that shows the current project stage: _Staging_. You will se also the _List of available CDI instances for MyBean_ table with two available implementations.
-
-Edit the file `src/main/resources/META-INF/apache-deltaspike.properties` and change the `org.apache.deltaspike.ProjectStage` property to `Development`. Deploy the application again
-
-[source]
-----
-    mvn clean package wildfly:deploy
-----
-
 Access the application again at the same URL: http://localhost:8080/wildfly-deltaspike-projectstage[http://localhost:8080/wildfly-deltaspike-projectstage]
 
-Look at _List of available CDI instances for MyBean_ table and realize that the available implementations has changed.
+Review the _List of available CDI instances for MyBean_ table to verify that the available implementations have changed.
 
-== Undeploy the Archive
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-When you are finished testing, type this command to undeploy the archive:
-
-[source]
-----
-mvn wildfly:undeploy
-----
-
-== Run the Quickstart in JBoss Developer Studio or Eclipse
-
-You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see link:../README.md#useeclipse[Use JBoss Developer Studio or Eclipse to Run the Quickstarts] 
+// Undeploy the Quickstart
+include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application
 

--- a/dist/buildReadmes.sh
+++ b/dist/buildReadmes.sh
@@ -1,0 +1,106 @@
+## asciidoctor -t -dbook -a toc -o README.html README.adoc
+## cd shared-doc/
+## asciidoctor -t -dbook -a toc -o development-shortcuts.html development-shortcuts.adoc
+## asciidoctor -t -dbook -a toc -o system-requirements.html system-requirements.adoc
+## cd ../kitchensink
+## asciidoctor -t -dbook -a toc -o README.html README.adoc
+## cd ../
+
+usage(){
+  cat <<EOM
+USAGE: $0 [OPTION]... <guide>
+
+DESCRIPTION: Build all of the guides (default), a single guide, and (optionally)
+produce pot/po files for translation.
+
+Run this script from the root of your cloned repo or from the 'scripts'
+directory.  Example:
+  cd eap-quickstart/
+  $0
+
+OPTIONS:
+  -h       Print help.
+
+EXAMPLES:
+  Build all quickstarts:
+   $0
+
+  Build a specific quickstart(s):
+    $0 kitchensink
+    $0 kitchensink number-guess
+
+EOM
+# Now list the valid quickstart names
+listquickstarts
+}
+
+
+listquickstarts(){
+  echo ""
+  echo "  Valid book argument values are:"
+
+  subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "dist" ! -iname "shared" ! -iname "src" | sort`
+  for subdir in $subdirs
+  do
+    echo "   ${subdir##*/}"
+  done
+  echo ""
+  # Return to where we started as a courtesy.
+}
+
+
+OPTIND=1
+while getopts "ht" c
+ do
+     case "$c" in
+       h)         usage
+                  exit 1;;
+       \?)        echo "Unknown option: -$OPTARG." >&2
+                  usage
+                  exit 1;;
+     esac
+ done
+shift $(($OPTIND - 1))
+
+
+CURRENT_DIR="$( pwd -P)"
+SCRIPT_SRC="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"
+QS_BASE="$( dirname $SCRIPT_SRC )"
+
+echo "CURRENT_DIR = $CURRENT_DIR"
+echo "SCRIPT_SRC = $SCRIPT_SRC"
+echo "QS_BASE = $QS_BASE"
+
+# Set the list of quickstart README files to build to whatever the user passed in (if anyting)
+cd $QS_BASE
+
+subdirs=$@
+if [ $# -gt 0 ]; then
+  # Strip off any ending forward slash
+  subdirs=${@%/}
+  echo "=== Bulding $subdirs ==="
+else
+  echo "=== Building all the quickstarts ==="
+  # Build the root README first
+  asciidoctor -t -dbook -a toc -o README.html README.adoc
+  # Recurse through the guide directories and build them.
+  subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "dist" ! -iname "shared" | sort`
+fi
+echo $PWD
+for subdir in $subdirs
+do
+  echo "Building ${subdir##*/}"
+  # Navigate to the dirctory and build it
+  if ! [ -e ${subdir##*/} ]; then
+    BUILD_MESSAGE="$BUILD_MESSAGE\nERROR: ${subdir##*/} does not exist."
+    # This is a book argument error so we should list the valid arguments.
+    LIST_BOOKS="true"
+    continue
+  fi
+  cd ${subdir##*/}
+  GUIDE_NAME=${PWD##*/}
+  asciidoctor -t -dbook -a toc -o README.html README.adoc
+  # Return to the parent directory
+  cd $QS_BASE
+done
+

--- a/ejb-asynchronous/README.adoc
+++ b/ejb-asynchronous/README.adoc
@@ -1,15 +1,9 @@
-= ejb-asynchronous: EJB with asynchronous methods
-:author: Wolf-Dieter Fink
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ejb-asynchronous: EJB with asynchronous methods
+:author: Wolf-Dieter Fink
 :level: Advanced
 :technologies: Asynchronous EJB
-:source: {githubRepoUrl}
 
 [abstract]
 The `ejb-asynchronous` quickstart demonstrates the behavior of asynchronous EJB invocations by a deployed EJB and a remote client and how to handle errors.
@@ -35,35 +29,15 @@ This example consists of the following Maven projects, each with a shared parent
 
 The root `pom.xml` builds each of the subprojects in the above order and deploys the archive to the server.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+//  System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Install the quickstart parent artifact
-//*************************************************
-// == Install the Quickstart Parent Artifact in Maven
+// Install the Quickstart Parent Artifact in Maven
 include::../shared-doc/install-quickstart-parent-artifact.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Build and deploy the quickstart JAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -104,16 +78,9 @@ The second message appears after the client is finished, approximately 15 second
 action 'fireAndForget' finished
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -128,8 +95,5 @@ This quickstart consists of multiple projects, so it deploys and runs differentl
 ** The client output displays in the *Console* window.
 . To undeploy the project, right-click on the *{artifactId}-ejb* project and choose *Run As* -> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/ejb-in-ear/README.adoc
+++ b/ejb-in-ear/README.adoc
@@ -1,21 +1,19 @@
-= ejb-in-ear: Deployment of an EAR Containing a JSF WAR and EJB JAR
-:author: Paul Robinson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ejb-in-ear: Deployment of an EAR Containing a JSF WAR and EJB JAR
+:author: Paul Robinson
 :level: Intermediate
 :technologies: EJB, EAR
-:source: {githubRepoUrl}
 
 [abstract]
 The `ejb-in-ear` quickstart demonstrates how to deploy an EAR archive that contains a *JSF* WAR and an EJB JAR.
 
 :standalone-server-type: default
 :archiveType: ear
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -48,29 +46,19 @@ The example follows the common "Hello World" pattern, using the following workfl
 . The managed bean is annotated as `@SessionScoped`, so the same managed bean instance is used for the entire session. This ensures that the message is available when the page reloads and is displayed to the user.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart EAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -78,17 +66,9 @@ The application will be running at the following URL http://localhost:8080/{arti
 
 Enter a name in the input field and click the *Greet* button to see the response.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -99,8 +79,26 @@ For this quickstart, follow the special instructions to build link:{useEclipseDe
 . This starts the server, deploys the application, and opens a browser window that accesses the running application.
 . To undeploy the project, right-click on the *{artifactId}-ear* project and choose *Run As* -> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/ejb-in-war/README.adoc
+++ b/ejb-in-war/README.adoc
@@ -1,21 +1,19 @@
-= ejb-in-war: Deployment of a WAR Containing an EJB
-:author: Paul Robinson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ejb-in-war: Deployment of a WAR Containing an EJB
+:author: Paul Robinson
 :level: Intermediate
 :technologies: EJB, JSF, WAR
-:source: {githubRepoUrl}
 
 [abstract]
 The `ejb-in-war` quickstart demonstrates how to package an EJB bean in a WAR archive and deploy it to {productName}. Arquillian tests are also provided.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -29,45 +27,29 @@ The example follows the common "Hello World" pattern using the following workflo
 . The response from invoking the `GreeterEJB` is stored in a field `message` of the managed bean.
 . The managed bean is annotated as `@SessionScoped`, so the same managed bean instance is used for the entire session. This ensures that the message is available when the page reloads and is displayed to the user.
 
+
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
 
 The application will be running at the following URL http://localhost:8080/{artifactId}/.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
 
 == Investigate the Console Output
@@ -92,20 +74,29 @@ INFO  [org.jboss.as.server] (management-handler-thread - 29) WFLYSRV0010: Deploy
 INFO  [org.jboss.as.server] (management-handler-thread - 30) WFLYSRV0009: Undeployed "test.war" (runtime-name: "test.war")
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/ejb-multi-server/README.adoc
+++ b/ejb-multi-server/README.adoc
@@ -1,15 +1,9 @@
-= ejb-multi-server: EJB Communication Across Servers
-:author: Wolf-Dieter Fink
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ejb-multi-server: EJB Communication Across Servers
+:author: Wolf-Dieter Fink
 :level: Advanced
 :technologies: EJB, EAR
-:source: {githubRepoUrl}
 
 [abstract]
 The `ejb-multi-server` quickstart shows how to communicate between multiple applications deployed to different servers using an EJB to log the invocation.
@@ -48,16 +42,9 @@ The root `pom.xml` builds each of the subprojects in an appropriate order.
 
 The server configuration is done using CLI batch scripts located in the root of the quickstart folder.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 [[start_with_a_clean_server_install]]
@@ -92,17 +79,9 @@ NOTE: For Windows, use the `__{jbossHomeName}__\bin\add-user.bat` script.
 
 If you prefer, you can use the `add-user` utility interactively. For an example of how to use the add-user utility, see the instructions located here: link:{addApplicationUserDocUrl}[Add an Application User].
 
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Managed Domain Configuration
+// Back Up the {productName} Managed Domain Configuration
 include::../shared-doc/back-up-managed-domain-configuration.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Start the managed domain
-//*************************************************
-// == Start the {productName} Managed Domain
+// Start the {productName} Managed Domain
 include::../shared-doc/start-the-managed-domain.adoc[leveloffset=+1]
 
 [[configure_the_server]]
@@ -136,10 +115,7 @@ IMPORTANT: Depending on your machine configuration, you might see "Exception in 
 
 There are too many additions to the configuration files to list here. Feel free to compare the `domain.xml` and `host.xml` to the backup copies to see the changes made to configure the server to run this quickstart.
 
-//*************************************************
-// Install the quickstart parent artifact
-//*************************************************
-// == Install the Quickstart Parent Artifact in Maven
+// Install the Quickstart Parent Artifact in Maven
 include::../shared-doc/install-quickstart-parent-artifact.adoc[leveloffset=+1]
 
 
@@ -263,23 +239,13 @@ $ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=undeploy-domain.cli
 NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat`.
 
 
-//******************************************************
-// Restore the domain configuration manually
-//******************************************************
-// == Restore the {productName} Managed Domain Configuration Manually
+// Restore the {productName} Managed Domain Configuration Manually
 include::../shared-doc/restore-managed-domain-configuration-manual.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
 EJB Client (ejb-client) currently has limited support in the Eclipse Web Tools Platform (WTP).
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/ejb-remote/README.adoc
+++ b/ejb-remote/README.adoc
@@ -1,15 +1,9 @@
-= ejb-remote: Remote EJB Client Example
-:author: Jaikiran Pai, Mike Musgrove
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ejb-remote: Remote EJB Client Example
+:author: Jaikiran Pai, Mike Musgrove
 :level: Intermediate
 :technologies: EJB, JNDI
-:source: {githubRepoUrl}
 
 [abstract]
 The `ejb-remote` quickstart uses EJB and JNDI to demonstrate how to access an EJB, deployed to {productName}, from a remote Java client application.
@@ -36,35 +30,15 @@ The remote client application depends on the remote business interfaces from the
 
 Each component is defined in its own standalone Maven module. The quickstart provides a top level Maven module to simplify the packaging of the artifacts.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Install the quickstart parent artifact
-//*************************************************
-// == Install the Quickstart Parent Artifact in Maven
+// Install the Quickstart Parent Artifact in Maven
 include::../shared-doc/install-quickstart-parent-artifact.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Build and deploy the quickstart JAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Build and Run the Client Application
@@ -179,16 +153,9 @@ You can use HTTP as the transport for remote EJB invocations by specifying `-Dht
 
 Before you can use it, you need to set up a user on the server as HTTP does not support transparent authentication. The next section describes how to xref:add_the_application_user[add the authorized application user] so you can test the quickstart using HTTP as the transport.
 
-//*************************************************
 // Add the Authorized Application User
-//*************************************************
-// == Add the Authorized Application User
 include::../shared-doc/add-application-user.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -205,10 +172,6 @@ This quickstart consists of multiple projects, so it deploys and runs differentl
 ** The client output displays in the *Console* window.
 . To undeploy the project, right-click on the *{artifactId}-server-side* project and choose *Run As* -> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 
-== Debug the Application
+//  Debug the Application
+include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
 
-If you want to debug the source code of any library in the project, run the following command to pull the source into your local repository. The IDE should then detect it.
-
-----
-mvn dependency:sources
-----

--- a/ejb-security-context-propagation/README.adoc
+++ b/ejb-security-context-propagation/README.adoc
@@ -1,15 +1,9 @@
-= ejb-security-context-propagation: Demonstrate security context propagation in EJB to remote EJB calls
-:author: Stefan Guilhen
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ejb-security-context-propagation: Demonstrate security context propagation in EJB to remote EJB calls
+:author: Stefan Guilhen
 :level: Advanced
 :technologies: EJB, Security
-:source: {githubRepoUrl}
 
 [abstract]
 The `ejb-security-context-propagation` quickstart demonstrates how the security context can be propagated to a remote EJB using a remote outbound connection configuration
@@ -17,6 +11,9 @@ The `ejb-security-context-propagation` quickstart demonstrates how the security 
 :standalone-server-type: default
 :archiveType: jar
 :includes-cli-scripts:
+:restoreScriptName: restore-configuration.cli
+:app-user-groups: guest,user
+:admin-user-groups: guest,user,admin
 
 == What is it?
 
@@ -63,16 +60,9 @@ Finally there is the `RemoteClient` stand-alone client. The client makes calls u
 In the real world, remote calls between servers in the servers-to-server scenario would truly be remote and separate.
 For the purpose of this quickstart, we make use of a loopback connection to the same server so we do not need two servers just to run the test.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 == Prerequisites
@@ -81,24 +71,11 @@ This quickstart uses the default standalone configuration plus the modifications
 
 It is recommended that you test this approach in a separate and clean environment before you attempt to port the changes in your own environment.
 
-//*****************************************************
 // Add the Authorized Application and Management Users
-//*****************************************************
-// ==  Add the Authorized Application and Management Users
-:app-user-groups: guest,user
-:admin-user-groups: guest,user,admin
 include::../shared-doc/add-application-and-management-users.adoc[leveloffset=+1]
-
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+//  Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 [[configure_the_server]]
@@ -219,10 +196,7 @@ For the purpose of the quickstart we just need an outbound connection that loops
 <log-system-exceptions value="false"/>
 ----
 
-//*************************************************
-// Build and deploy the quickstart JAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart JAR
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Run the Client
@@ -307,18 +281,9 @@ authorized.
     at java.lang.Thread.run(Thread.java:745)
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: restore-configuration.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -340,16 +305,9 @@ The batch executed successfully
 ----
 ====
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -364,8 +322,5 @@ This quickstart requires additional configuration and deploys and runs different
 . To undeploy the project, right-click on the *{artifactId}* project and choose *Run As* -> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 . Make sure you xref:restore_the_server_configuration[restore the server configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/ejb-security-jaas/README.adoc
+++ b/ejb-security-jaas/README.adoc
@@ -1,15 +1,9 @@
-= ejb-security-jaas: Using the legacy JAAS security domains to secure JEE applications
-:author: Stefan Guilhen
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ejb-security-jaas: Using the legacy JAAS security domains to secure JEE applications
+:author: Stefan Guilhen
 :level: Intermediate
 :technologies: EJB, Security
-:source: {githubRepoUrl}
 
 [abstract]
 The `ejb-security-jaas` quickstart demonstrates how legacy `JAAS` security domains can be used in conjunction with `Elytron`
@@ -17,6 +11,7 @@ The `ejb-security-jaas` quickstart demonstrates how legacy `JAAS` security domai
 :standalone-server-type: default
 :archiveType: war
 :includes-cli-scripts:
+:restoreScriptName: restore-configuration.cli
 
 == What is it?
 
@@ -31,16 +26,9 @@ The following steps required to use the `JAAS` integration.
 5. Setup a `sasl-authentication-factory` in the `elytron` subsystem to handle the requests made by remote clients.
 6. Add the `application-security-domain` mappings to both `ejb3` and `undertow` subsystems to enable `Elytron` security for the EJB3 and web components.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 [[create_the_properties_files_for_the_jaas_security_domain]]
@@ -69,16 +57,9 @@ quickstartUser=guest
 
 This concludes the configuration required by the legacy `JAAS` login module used in this quickstart.
 
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 [[configure_the_server]]
@@ -222,10 +203,7 @@ Authentication performed by the quickstart remote client is handled by this SASL
 +
 This mapping basically enables `Elytron` security for EJB3 applications that specify the security domain `legacy-domain` in their metadata (either via jboss-ejb3.xml or annotations). The quickstart application uses the `@SecurityDomain` annotation in the bean class to specify this security domain.
 
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart WAR
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 [[access_the_application]]
@@ -342,18 +320,9 @@ ERROR [org.jboss.as.ejb3.invocation] (default task-1) WFLYEJB0034: EJB Invocatio
 
 After you enable the legacy security domain role mappers in the exported realm, the `quickstartUser` will have `admin` role access and you will no longer see the exception in the server log.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: restore-configuration.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -365,10 +334,7 @@ The batch executed successfully
 process-state: reload-required
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+//  Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
 
 == Remove the Properties Files from the Server
@@ -376,10 +342,7 @@ include::../shared-doc/restore-standalone-server-configuration-manual.adoc[level
 After you are done with this quickstart, remember to remove the `users.properties` and `roles.properties` files from the
 server configuration directory (`__{jbossHomeName}__/standalone/configuration/`).
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -392,8 +355,5 @@ include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[levelof
 * To undeploy the project, right-click on the *{artifactId}* project and choose *Run As* -> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 * Make sure you xref:restore_the_server_configuration[restore the server configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/ejb-security-programmatic-auth/README.adoc
+++ b/ejb-security-programmatic-auth/README.adoc
@@ -1,15 +1,9 @@
-= ejb-security-programmatic-auth: Using the programmatic API to invoke a remote EJB using different identities
-:author: Stefan Guilhen
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ejb-security-programmatic-auth: Using the programmatic API to invoke a remote EJB using different identities
+:author: Stefan Guilhen
 :level: Intermediate
 :technologies: EJB, Security
-:source: {githubRepoUrl}
 
 [abstract]
 The `ejb-security-programmatic-auth` quickstart demonstrates how to programmatically setup different identities when invoking a remote secured EJB.
@@ -17,41 +11,23 @@ The `ejb-security-programmatic-auth` quickstart demonstrates how to programmatic
 :standalone-server-type: default
 :archiveType: jar
 :includes-cli-scripts:
+:restoreScriptName: restore-configuration.cli
+:app-user-groups: guest
+:admin-user-groups: guest,admin
 
 == What is it?
 
 The `ejb-security-programmatic-auth` quickstart demonstrates how to invoke a remote secured EJB using the `Elytron` client API to establish different identities. The quickstart client application accomplishes that by looking up and invoking the secured EJB under different `AuthenticationContext`s. Each context is setup to use a different identities and credentials.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*****************************************************
 // Add the Authorized Application and Management Users
-//*****************************************************
-// ==  Add the Authorized Application and Management Users
-:app-user-groups: guest
-:admin-user-groups: guest,admin
 include::../shared-doc/add-application-and-management-users.adoc[leveloffset=+1]
-
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 [[configure_the_server]]
@@ -109,10 +85,7 @@ The `application-security-domain` essentially enables Elytron security for the q
 +
 This allows for the identity that was established in the connection authentication to be propagated to the components.
 
-//*************************************************
-// Build and deploy the quickstart JAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -147,18 +120,9 @@ Principal has admin permission: true
 
 As expected, the `quickstart` user is able to call the methods available for `guest`, but does not have the `admin` permission to call administrative methods on the remote EJB. The `quickstartAdmin` on the other hand has permissions to call both methods.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: restore-configuration.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -170,16 +134,9 @@ The batch executed successfully
 process-state: reload-required
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -207,8 +164,5 @@ Principal has admin permission: true
 
 * Make sure you xref:restore_the_server_configuration[restore the {productName} standalone server configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/ejb-security/README.adoc
+++ b/ejb-security/README.adoc
@@ -1,15 +1,9 @@
-= ejb-security:  Using Java EE Declarative Security to Control Access
-:author: Sherif F. Makary, Stefan Guilhen
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ejb-security:  Using Java EE Declarative Security to Control Access
+:author: Sherif F. Makary, Stefan Guilhen
 :level: Intermediate
 :technologies: EJB, Security
-:source: {githubRepoUrl}
 
 [abstract]
 The `ejb-security` quickstart demonstrates the use of Java EE declarative security to control access to EJBs in {productName}.
@@ -17,6 +11,8 @@ The `ejb-security` quickstart demonstrates the use of Java EE declarative securi
 :standalone-server-type: default
 :archiveType: jar
 :includes-cli-scripts:
+:restoreScriptName: restore-configuration.cli
+:app-user-groups: guest
 
 == What is it?
 
@@ -33,35 +29,15 @@ to users with `admin` role access rights.
 password `quickstartPwd1!` in the `guest` role. The `guest` role matches the allowed user role defined in the `@RolesAllowed`
 annotation in the EJB but it should not be granted access to the administrative method annotated with `RolesAllowed({&quot;admin&quot;})`.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
 // Add the Authorized Application User
-//*************************************************
-// == Add the Authorized Application User
-:app-user-groups: guest
 include::../shared-doc/add-application-user.adoc[leveloffset=+1]
-
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 [[configure_the_server]]
@@ -119,10 +95,7 @@ The `application-security-domain` enables Elytron security for the quickstart EJ
 +
 This configuration allows the identity that was established at the connection level to be propagated to the components.
 
-//*************************************************
-// Build and deploy the quickstart JAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 
@@ -185,18 +158,9 @@ Principal has admin permission: true
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: restore-configuration.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -208,17 +172,9 @@ The batch executed successfully
 process-state: reload-required
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -230,8 +186,5 @@ include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[levelof
 . To undeploy the project, right-click on the *{artifactId}* project and choose *Run As* –> *Run Configurations*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 . Make sure you xref:restore_the_server_configuration[restore the server configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/ejb-throws-exception/README.adoc
+++ b/ejb-throws-exception/README.adoc
@@ -1,15 +1,9 @@
-= ejb-throws-exception: Handle Exceptions across JARs in an EAR
-:author: Brad Maxwell
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ejb-throws-exception: Handle Exceptions across JARs in an EAR
+:author: Brad Maxwell
 :level: Intermediate
 :technologies: EJB, EAR
-:source: {githubRepoUrl}
 
 [abstract]
 The `ejb-throws-exception` quickstart demonstrates how to throw and handle exceptions across JARs in an EAR.
@@ -64,28 +58,13 @@ The example follows the common "Hello World" pattern, using the following workfl
 . The managed bean is annotated as `@RequestScoped`, so the same managed bean instance is used only for the request/response.
 
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart EAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -98,17 +77,9 @@ The *Response* output text will display the response from the EJB.
 If the *Name* input text box is not empty, then the *Response* output text will display *Hello <name>*
 If the *Name* input text box is empty, then the *Response* output text will display the message of the exception throw back from the EJB.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -119,8 +90,5 @@ For this quickstart, follow the special instructions to build link:{useEclipseDe
 . This starts the server, deploys the application, and opens a browser window that accesses the running application.
 . To undeploy the project, right-click on the *{artifactId}-ear* project and choose *Run As* -> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/ejb-timer/README.adoc
+++ b/ejb-timer/README.adoc
@@ -1,21 +1,19 @@
-= ejb-timer: Example of EJB Timer Service - @Schedule and @Timeout
-:author: Ondrej Zizka <ozizka@redhat.com>
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ejb-timer: Example of EJB Timer Service - @Schedule and @Timeout
+:author: Ondrej Zizka <ozizka@redhat.com>
 :level: Beginner
 :technologies: EJB Timer
-:source: {githubRepoUrl}
 
 [abstract]
 The `ejb-timer` quickstart demonstrates how to use the EJB timer service `@Schedule` and `@Timeout` annotations with {productName}.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -27,27 +25,18 @@ The following EJB Timer services are demonstrated:
 * `@Timeout`: Uses this annotation to mark a method to execute when a programmatic timer goes off. This example sets the timer to go off every 3 seconds, at which point the method prints a message to the server console.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -77,27 +66,30 @@ INFO  [stdout] (EJB default - 7) ScheduleExample.doWork() invoked at 2014.11.25 
 
 Existing threads in the thread pool handle the invocations. They are rotated and the name of the thread that handles the invocation is printed within the parenthesis `(EJB Default - #)`.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/greeter/README.adoc
+++ b/greeter/README.adoc
@@ -1,21 +1,17 @@
-= greeter: Demonstrates CDI, JPA, JTA, EJB, and JSF
-:author: Pete Muir
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= greeter: Demonstrates CDI, JPA, JTA, EJB, and JSF
+:author: Pete Muir
 :level: Beginner
 :technologies: CDI, JSF, JPA, EJB, JTA
-:source: {githubRepoUrl}
 
 [abstract]
 The `greeter` quickstart demonstrates the use of CDI, JPA, JTA, EJB and JSF in {productName}.
 
 :standalone-server-type: default
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
 
 == What is it?
 
@@ -31,46 +27,29 @@ To test this example:
 . To create a new user, click the *Add a new user* link. Enter the *username*, *first name*, and *last name*, and then click *Add User*. The user is added and a message displays the new user id number.
 . Click on the `Greet a user!` link to return to the `Greet!` page.
 
+
 //*************************************************
-// Add notes about use in a production environment.
+// Product Release content only
 //*************************************************
-:uses-h2:
-:uses-ds-xml:
-// == Considerations for Use in a Production Environment
+
+ifndef::EAPCDRelease[]
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
 
 The application will be running at the following URL: http://localhost:8080/{artifactId}/.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
 
@@ -83,20 +62,29 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/ha-singleton-deployment/README.adoc
+++ b/ha-singleton-deployment/README.adoc
@@ -1,15 +1,9 @@
-= ha-singleton-deployment: Deploying Cluster-wide Singleton Services Using Singleton Deployments
-:author: Radoslav Husar
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ha-singleton-deployment: Deploying Cluster-wide Singleton Services Using Singleton Deployments
+:author: Radoslav Husar
 :level: Advanced
 :technologies: EJB, Singleton Deployments, Clustering
-:source: {githubRepoUrl}
 
 [abstract]
 The `ha-singleton-deployment` quickstart demonstrates the recommended way to deploy any service packaged in an application archive as a cluster-wide singleton.
@@ -28,16 +22,9 @@ The example is built and packaged as a single EJB archive.
 
 For more information about singleton deployments, see _HA Singleton Deployments_ in the {LinkDevelopmentGuide}[__{DevelopmentBookName}__] for {DocInfoProductName} located on the Red Hat Customer Portal.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}_1 and {jbossHomeName}_2
+// Use of {jbossHomeName}_1 and {jbossHomeName}_2
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 == Setting Up the Test Environment
@@ -238,14 +225,7 @@ $ mvn wildfly:undeploy
 $ mvn wildfly:undeploy -Dwildfly.port=10090
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/ha-singleton-service/README.adoc
+++ b/ha-singleton-service/README.adoc
@@ -1,15 +1,9 @@
-= ha-singleton-service: Deploying Cluster-wide Singleton MSC Services
-:author: Radoslav Husar
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= ha-singleton-service: Deploying Cluster-wide Singleton MSC Services
+:author: Radoslav Husar
 :level: Advanced
 :technologies: MSC, Singleton Service, Clustering
-:source: {githubRepoUrl}
 
 [abstract]
 The `ha-singleton-service` quickstart demonstrates how to deploy a cluster-wide singleton MSC service.
@@ -37,16 +31,9 @@ These examples are built and packaged as JAR archives.
 
 For more information about clustered singleton services, see _HA Singleton Service_ in the {LinkDevelopmentGuide}[__{DevelopmentBookName}__] for {DocInfoProductName} located on the Red Hat Customer Portal.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}_1 and {jbossHomeName}_2
+// Use of {jbossHomeName}_1 and {jbossHomeName}_2
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 == Clone the {productName} Directory
@@ -521,14 +508,7 @@ $ __{jbossHomeName}_2__/bin/jboss-cli.sh --connect --controller=localhost:10090 
 +
 NOTE: For Windows, use the `__{jbossHomeName}_1__\bin\jboss-cli.bat` and `__{jbossHomeName}_2__\bin\jboss-cli.bat` scripts.
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/helloworld-classfiletransformer/README.adoc
+++ b/helloworld-classfiletransformer/README.adoc
@@ -1,15 +1,9 @@
-= WildFly Examples: Applying ClassTransformers to your Java EE archive
-:author: Stuart Douglas
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-classfiletransformer: Applying ClassTransformers to your Java EE archive
+:author: Stuart Douglas
 :level: Advanced
 :technologies: ClassLoading
-:source: {githubRepoUrl}
 
 [abstract]
 This is a WAR based application showing you how Wildfly let you apply a ClassTransformer to the classes in your enterprise archive.
@@ -38,11 +32,11 @@ It is the EJB's implementation class, HelloBean, that is modified in this exampl
 The modification is really simple: it simply injects logging statements before and after the sayHello() method.
 But Javaassist can do much more - check out the relevant documentation for Javassist.
 Or choose another bytecode generation library.
-The choice is yours - Wildfly doesn't care what you choose. 
+The choice is yours - Wildfly doesn't care what you choose.
 
 You could achieve the same effect using EJB interceptors or CDI interceptors. They are standard and would normally be the recommended way to go about "around" behavior.
 But Java EE interceptors are not as powerful as bytecode manipulation can be: with bytecode manipulation you can easily advice unmanaged classes (including static member methods etc), "add/remove" interfaces, fields, methods and so on.
-And you can even advice code that is a third party dependency to your application (say Apache Commons library code). 
+And you can even advice code that is a third party dependency to your application (say Apache Commons library code).
 
 Deploy the WAR
 ========================
@@ -61,7 +55,7 @@ Upon deployment you should see something like: "Instrumenting hello.server.ejb.H
 That is the example class transformer that tells you it has instrumented the HelloBean EJB.
 
 Upon calling the EJB's web service endpoint you should see something like: "INTERCEPTED MethodInvocation".
-One line before the method invocation. And one line after the method invocation. 
+One line before the method invocation. And one line after the method invocation.
 
 Do make sure to verify that these lines hasn't just been printed by the EJB's sayHello() method.
 

--- a/helloworld-html5/README.adoc
+++ b/helloworld-html5/README.adoc
@@ -1,15 +1,9 @@
-= helloworld-html5: HTML5 and REST Hello World Example
-:author: Jay Balunas, Burr Sutter, Douglas Campos, Bruno Olivera
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-html5: HTML5 and REST Hello World Example
+:author: Jay Balunas, Burr Sutter, Douglas Campos, Bruno Olivera
 :level: Beginner
 :technologies: CDI, JAX-RS, HTML5
-:source: {githubRepoUrl}
 
 [abstract]
 The `helloworld-html5` quickstart demonstrates the use of CDI 1.2 and JAX-RS 2.0 using the HTML5 architecture and RESTful services on the backend.
@@ -30,9 +24,12 @@ The application is basically a smart, HTML5, CSS3, and JavaScript front-end usin
 The example can be deployed using Maven from the command line or from Eclipse using JBoss Tools.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 
 // Additional requirements for this quickstart.
@@ -40,23 +37,11 @@ An HTML5 compatible browser such as Chrome, Safari 5+, Firefox 5+, or IE 9+ is r
 
 With the prerequisites out of the way, you are ready to build and deploy.
 
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
-// include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -119,29 +104,12 @@ Date: Tue, 13 Oct 2015 06:32:20 GMT
 {"result":"Hello YOUR_NAME!"}
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Run the Arquillian functional tests
-//*************************************************
-// == Run the Arquillian Functional Tests
+// Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
 
 == Debug the Application
 
@@ -152,3 +120,24 @@ If you want to debug the source code or look at the Javadocs of any library in t
 $ mvn dependency:sources
 $ mvn dependency:resolve -Dclassifier=javadoc
 ----
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/helloworld-jms/README.adoc
+++ b/helloworld-jms/README.adoc
@@ -1,15 +1,9 @@
-= helloworld-jms: Helloworld JMS Example
-:author: Weston Price
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-jms: Helloworld JMS Example
+:author: Weston Price
 :level: Intermediate
 :technologies: JMS
-:source: {githubRepoUrl}
 
 [abstract]
 The `helloworld-jms` quickstart demonstrates the use of external JMS clients with {productName}.
@@ -17,6 +11,8 @@ The `helloworld-jms` quickstart demonstrates the use of external JMS clients wit
 :standalone-server-type: full
 :archiveType: jar
 :includes-cli-scripts:
+:restoreScriptName: remove-jms.cli
+:app-user-groups: guest
 
 == What is it?
 
@@ -28,35 +24,15 @@ It contains the following:
 
 . A message consumer that receives message from a JMS destination deployed to a {productName} server.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
 // Add the Authorized Application User
-//*************************************************
-// == Add the Authorized Application User
-:app-user-groups: guest
 include::../shared-doc/add-application-user.adoc[leveloffset=+1]
-
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the full profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 [[configure_the_server]]
@@ -189,11 +165,7 @@ The example provides for a certain amount of customization for the `mvn:exec` pl
 | This property allows configuration of the JNDI directory used to look up the JMS destination. This is useful when the client resides on another host.
 |===
 
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: remove-jms.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -204,16 +176,9 @@ This script removes the `test` queue from the `messaging` subsystem in the serve
 The batch executed successfully
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -228,8 +193,5 @@ This quickstart consists of multiple projects, so it deploys and runs differentl
 The output messages appear in the *Console* window.
 . Make sure you xref:restore_the_server_configuration[restore the {productName} server configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/helloworld-mbean/README.adoc
+++ b/helloworld-mbean/README.adoc
@@ -1,15 +1,9 @@
-= helloworld-mbean: Helloworld Using MBean and CDI component
-:author: Lagarde Jeremie
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-mbean: Helloworld Using MBean and CDI component
+:author: Lagarde Jeremie
 :level: Intermediate
 :technologies: CDI, JMX, MBean
-:source: {githubRepoUrl}
 :imagesdir: images/
 
 [abstract]
@@ -17,6 +11,7 @@ The `helloworld-mbean` quickstart demonstrates the use of CDI and MBean in {prod
 
 :standalone-server-type: default
 :archiveType: war
+:archiveName: {artifactId}-service
 
 == What is it?
 
@@ -41,29 +36,13 @@ The example is composed of the following MBeans.
 | This MBean is a pojo using `MXBean` interface and declared in the `jboss-service.xml` file using SAR packaging.
 |===
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart JAR
-//*************************************************
-// == Build and Deploy the Quickstart
-:archiveName: {artifactId}-service
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 // Additional deployment information
@@ -108,24 +87,11 @@ image:jconsole.png[MBeans in JConsole]
 * For the *AnnotatedComponentHelloWorld* and *MXComponentHelloWorld* examples, you will see a popup Window displaying *Hello <your name>!*.
 * For the *MXPojoHelloWorld* and *SarMXPojoHelloWorld* examples, you will see a popup Window displaying *Welcome <your name>!*.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -142,10 +108,5 @@ This quickstart consists of multiple projects and requires installation of the `
 . To undeploy the web application, right-click on the *{artifactId}-wepapp* project and choose *Run As* -> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 . To undeploy the web service, right-click on the *{artifactId}-service* project and choose *Run As* -> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 
-== Debug the Application
-
-If you want to debug the source code of any library in the project, run the following command to pull the source into your local repository. The IDE should then detect it.
-
-----
-$ mvn dependency:sources
-----
+// Debug the Application
+include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/helloworld-mdb-propertysubstitution/README.adoc
+++ b/helloworld-mdb-propertysubstitution/README.adoc
@@ -1,15 +1,9 @@
-= helloworld-mdb-propertysubstitution: MDB (Message-Driven Bean) Using Property Substitution
-:author: Serge Pagop, Andy Taylor, Jeff Mesnil
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-mdb-propertysubstitution: MDB (Message-Driven Bean) Using Property Substitution
+:author: Serge Pagop, Andy Taylor, Jeff Mesnil
 :level: Intermediate
 :technologies: JMS, EJB, MDB
-:source: {githubRepoUrl}
 
 [abstract]
 The `helloworld-mdb-propertysubstitution` quickstart demonstrates the use of JMS and EJB MDB, enabling property substitution with annotations.
@@ -17,6 +11,7 @@ The `helloworld-mdb-propertysubstitution` quickstart demonstrates the use of JMS
 :standalone-server-type: full
 :archiveType: war
 :includes-cli-scripts:
+:restoreScriptName: disable-mdb-property-substitution.cli
 
 == What is it?
 
@@ -29,30 +24,14 @@ This project creates two JMS resources:
 * A queue named `HELLOWORLDMDBQueue` bound in JNDI as `java:/${property.helloworldmdb.queue}`
 * A topic named `HELLOWORLDMDBTopic` bound in JNDI as `java:/${property.helloworldmdb.topic}`
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the full profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
 
 [[configure_the_server]]
 == Configure the Server
@@ -110,10 +89,7 @@ The following system properties are defined and appear after the `<extensions>`:
 </system-properties>
 ----
 
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 // Additional instructions.
@@ -152,18 +128,9 @@ INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldQueueMDB] (Thread-5 (ActiveM
 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldQueueMDB] (Thread-4 (ActiveMQ-client-global-threads-1189700957)) Received Message from queue: This is message 3
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: disable-mdb-property-substitution.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 This script removes the system properties and sets the `<annotation-property-replacement>` value to `false` in the `ee` subsystem of the server configuration. You should see the following result when you run the script:
@@ -173,17 +140,9 @@ This script removes the system properties and sets the `<annotation-property-rep
 The batch executed successfully
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -191,8 +150,5 @@ include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[levelof
 * Within JBoss Developer Studio, make sure you define a server runtime environment that uses the `standalone-full.xml` configuration file.
 * Make sure you xref:restore_the_server_configuration[restore the server configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/helloworld-mdb/README.adoc
+++ b/helloworld-mdb/README.adoc
@@ -1,21 +1,19 @@
-= helloworld-mdb: Helloworld Using an MDB (Message-Driven Bean)
-:author: Serge Pagop, Andy Taylor, Jeff Mesnil
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-mdb: Helloworld Using an MDB (Message-Driven Bean)
+:author: Serge Pagop, Andy Taylor, Jeff Mesnil
 :level: Intermediate
 :technologies: JMS, EJB, MDB
-:source: {githubRepoUrl}
 
 [abstract]
 The `helloworld-mdb` quickstart uses JMS and EJB Message-Driven Bean (MDB) to create and deploy JMS topic and queue resources in {productName}.
 
 :standalone-server-type: full
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -27,27 +25,18 @@ This project creates two JMS resources:
 * A topic named `HELLOWORLDMDBTopic` bound in JNDI as `java:/topic/HELLOWORLDMDBTopic`
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the full profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 // Additional deployment information
@@ -82,30 +71,35 @@ INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldQueueMDB] (Thread-5 (ActiveM
 INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldQueueMDB] (Thread-4 (ActiveMQ-client-global-threads-1189700957)) Received Message from queue: This is message 3
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
 NOTE: Within JBoss Developer Studio, make sure you define a server runtime environment that uses the `standalone-full.xml` configuration file.
 
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
+
+// Debug the Application
+include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
 
 //*************************************************
-// Add info to debug the application
+// CD Release content only
 //*************************************************
-// == Debug the Application
-include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/helloworld-mutual-ssl-secured/README.adoc
+++ b/helloworld-mutual-ssl-secured/README.adoc
@@ -1,15 +1,9 @@
-= helloworld-mutual-ssl-secured: Securing a Web Application with Mutual (two-way) SSL Configuration and Role-based Access Control
-:author: Giriraj Sharma, Stefan Guilhen
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-mutual-ssl-secured: Securing a Web Application with Mutual (two-way) SSL Configuration and Role-based Access Control
+:author: Giriraj Sharma, Stefan Guilhen
 :level: Intermediate
 :technologies: Mutual SSL, Security, Undertow
-:source: {githubRepoUrl}
 
 [abstract]
 The `helloworld-mutual-ssl-secured` quickstart demonstrates securing a Web application using client mutual SSL authentication and role-based access control
@@ -17,6 +11,8 @@ The `helloworld-mutual-ssl-secured` quickstart demonstrates securing a Web appli
 :standalone-server-type: default
 :archiveType: war
 :includes-cli-scripts:
+:restoreScriptName: restore-configuration.cli
+:app-user-groups: JBossAdmin
 
 == What is it?
 
@@ -26,24 +22,11 @@ Mutual SSL provides the same security as SSL, with the addition of authenticatio
 
 This quickstart shows how to configure {productName} to enable TLS/SSL configuration for the new {productName} `undertow` subsystem and enable mutual (two-way) SSL authentication for clients in order to secure a WAR application with restricted access.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Add the Authorized Application User
-//*************************************************
-// == Add the Authorized Application User
-:app-user-groups: JBossAdmin
-
+//  Add the Authorized Application User
 include::../shared-doc/add-application-user.adoc[leveloffset=+1]
 
 IMPORTANT: For the purpose of this quickstart the password can contain any valid value because the `ApplicationRealm` will be used for authorization only, for example, to obtain the security roles.
@@ -148,16 +131,9 @@ $>keytool -importkeystore -srckeystore client.keystore -srcstorepass secret -des
 
 . The certificates and keystores are now properly configured.
 
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 [[configure_the_server]]
@@ -327,10 +303,7 @@ Before you access the application, you must import the _clientCert.p12_, which h
 . Select the *clientCert.p12* file. You will be prompted to enter the password: `secret`.
 . The certificate is now installed in the Mozilla Firefox browser.
 
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 // Additional deployment information
@@ -361,18 +334,11 @@ dzXZz0EjjWCPJk+LVEhEvH0GcWAp3x3irpNU4hRZLd0XomY0Z4NnUt7VMBNYDOxVxgT9qcLnEaEpIfYU
 ynfnMaOxI67FC2QzhfzERyKqHj47WuwN0xWbS/1gBypS2nUwvItyxaEQG2X5uQY8j8QoY9wcMzIIkP2Mk14gJGHUnA8=
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
 
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: restore-configuration.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -384,10 +350,7 @@ The batch executed successfully
 process-state: reload-required
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
 
 == Remove the keystores and certificates created for this quickstart
@@ -426,10 +389,7 @@ After you are done with this quickstart, remember to remove the certificate that
 . Select the *quickstartUser* certificate and click the *Delete* button.
 . The certificate has now been removed from the Mozilla Firefox browser.
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -440,8 +400,5 @@ include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[levelof
 * To deploy the application, right-click on the *{artifactId}* project and choose *Run As* –> *Run on Server*.
 * Make sure you xref:restore_the_server_configuration[restore the {productName} server configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/helloworld-mutual-ssl/README.adoc
+++ b/helloworld-mutual-ssl/README.adoc
@@ -1,15 +1,9 @@
-= helloworld-mutual-ssl: {productName} Mutual SSL(two-way) Configuration Example
-:author: Giriraj Sharma, Stefan Guilhen
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-mutual-ssl: {productName} Mutual SSL(two-way) Configuration Example
+:author: Giriraj Sharma, Stefan Guilhen
 :level: Intermediate
 :technologies: Mutual SSL, Undertow
-:source: {githubRepoUrl}
 
 [abstract]
 The `helloworld-mutual-ssl` quickstart is a basic example that demonstrates mutual SSL configuration in {productName}
@@ -17,7 +11,7 @@ The `helloworld-mutual-ssl` quickstart is a basic example that demonstrates mutu
 :standalone-server-type: default
 :archiveType: war
 :includes-cli-scripts:
-
+:restoreScriptName: restore-configuration.cli
 
 == What is it?
 
@@ -27,16 +21,9 @@ This quickstart shows how to configure {productName} to enable TLS/SSL configura
 
 Before you run this example, you must create certificates and configure the server to use two-way SSL.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 [[set_up_client_and_server_keystores_using_java_keytool]]
@@ -134,16 +121,9 @@ $>keytool -importkeystore -srckeystore client.keystore -srcstorepass secret -des
 
 . The certificates and keystores are now properly configured.
 
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 
@@ -269,12 +249,8 @@ Before you access the application, you must import the _clientCert.p12_, which h
 . Select the *clientCert.p12* file. You will be prompted to enter the password: `secret`.
 . The certificate is now installed in the Mozilla Firefox browser.
 
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -299,18 +275,9 @@ DHo1uoz5/dzXZz0EjjWCPJk+LVEhEvH0GcWAp3x3irpNU4hRZLd0XomY0Z4NnUt7VMBNYDOxVxgT9qcL
 aEWK4zhPVFynfnMaOxI67FC2QzhfzERyKqHj47WuwN0xWbS/1gBypS2nUwvItyxaEQG2X5uQY8j8QoY9wcMzIIkP2Mk14gJGHUnA8=
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: restore-configuration.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -323,10 +290,7 @@ The batch executed successfully
 process-state: reload-required
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
 
 
@@ -365,10 +329,7 @@ After you are done with this quickstart, remember to remove the certificate that
 . Select the `quickstartUser` certificate and click the `Delete` button.
 . The certificate has now been removed from the Mozilla Firefox browser.
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions

--- a/helloworld-rf/README.adoc
+++ b/helloworld-rf/README.adoc
@@ -1,22 +1,16 @@
-= helloworld-rf: Helloworld with a JSF (JavaServer Faces) Front End
-:author: Brian Leathem
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-rf: Helloworld with a JSF (JavaServer Faces) Front End
+:author: Brian Leathem
 :level: Beginner
 :technologies: CDI, JSF, RichFaces
-:source: https://github.com/richfaces/as-quickstarts
 
 [abstract]
-Similar to the helloworld quickstart, but with a JSF front end
+Similar to the helloworld quickstart, but with a JSF front end.
 
 == What is it?
 
-This project demonstrates how to create a Java EE 7 compliant application using JSF 2.2, CDI 1.2, and RichFaces 4.5.
+This project demonstrates how to create a {javaVersion} compliant application using JSF 2.2, CDI 1.2, and RichFaces 4.5.
 
 In this example, a standard JSF `h:inputText` component is AJAX enabled using the RichFaces `a4j:ajax tag`. This triggers the application server to re-render only a subsection of the page on a browser event.
 
@@ -33,7 +27,7 @@ If you have not yet done so, you must link:../README.md#mavenconfiguration[Confi
 == Start JBoss WildFly with the Web Profile
 
 . Open a command line and navigate to the root of the JBoss server directory.
-. 
+.
 
 The following shows the command line to start the server with the web profile:
 
@@ -49,7 +43,7 @@ _NOTE: The following build command assumes you have configured your Maven user s
 
 . Make sure you have started the JBoss Server as described above.
 . Open a command line and navigate to the root directory of this quickstart.
-. 
+.
 
 Type this command to build and deploy the archive:
 
@@ -58,7 +52,7 @@ Type this command to build and deploy the archive:
 mvn clean package wildfly:deploy
 ----
 
-. 
+.
 
 This will deploy `target/wildfly-helloworld-rf.war` to the running instance of the server.
 
@@ -82,7 +76,7 @@ mvn wildfly:undeploy
 
 == Run the Quickstart in JBoss Developer Studio or Eclipse
 
-You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see link:../README.md#useeclipse[Use JBoss Developer Studio or Eclipse to Run the Quickstarts] 
+You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see link:../README.md#useeclipse[Use JBoss Developer Studio or Eclipse to Run the Quickstarts]
 
 == Debug the Application
 

--- a/helloworld-rs/README.adoc
+++ b/helloworld-rs/README.adoc
@@ -1,15 +1,9 @@
-= helloworld-rs: Helloworld Using JAX-RS (Java API for RESTful Web Services)
-:author: Gustavo A. Brey, Gaston Coco
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-rs: Helloworld Using JAX-RS (Java API for RESTful Web Services)
+:author: Gustavo A. Brey, Gaston Coco
 :level: Intermediate
 :technologies: CDI, JAX-RS
-:source: {githubRepoUrl}
 
 [abstract]
 The `helloworld-rs` quickstart demonstrates a simple Hello World application, bundled and deployed as a WAR, that uses JAX-RS to say Hello.
@@ -17,32 +11,30 @@ The `helloworld-rs` quickstart demonstrates a simple Hello World application, bu
 :standalone-server-type: default
 :archiveType: war
 
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
+
 == What is it?
 
 The `helloworld-rs` quickstart demonstrates the use of CDI and JAX-RS in {productNameFull}.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 
@@ -54,26 +46,31 @@ The application is deployed to http://localhost:8080/{artifactId}/.
 
 * The _JSON_ content can be viewed by accessing this URL: http://localhost:8080/{artifactId}/rest/json
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/helloworld-singleton/README.adoc
+++ b/helloworld-singleton/README.adoc
@@ -1,15 +1,9 @@
-= helloworld-singleton: Helloworld Using a Singleton EJB
-:author: Serge Pagop
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-singleton: Helloworld Using a Singleton EJB
+:author: Serge Pagop
 :level: Beginner
 :technologies: EJB, Singleton
-:source: {githubRepoUrl}
 
 [abstract]
 The `helloworld-singleton` quickstart demonstrates an EJB Singleton Bean that is instantiated once and maintains state for the life of the session.
@@ -17,34 +11,28 @@ The `helloworld-singleton` quickstart demonstrates an EJB Singleton Bean that is
 :standalone-server-type: default
 :archiveType: war
 
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
+
 == What is it?
 
 The `helloworld-singleton` quickstart demonstrates the use of an EJB Singleton Bean in {productNameFull}. It is instantiated once and maintains its state for the life of the session.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -56,27 +44,30 @@ A counter is incremented when you click on the link to the variable name. If you
 
 To test the singleton bean, click on either *Increment A* or *Increment B*. The result page will give you the current value of the variable.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/helloworld-ssl/README.adoc
+++ b/helloworld-ssl/README.adoc
@@ -1,15 +1,9 @@
-= helloworld-ssl: {productName} Server Side SSL Configuration Example
-:author: Giriraj Sharma, Stefan Guilhen
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-ssl: {productName} Server Side SSL Configuration Example
+:author: Giriraj Sharma, Stefan Guilhen
 :level: Beginner
 :technologies: SSL, Undertow
-:source: {githubRepoUrl}
 
 [abstract]
 The `helloworld-ssl` quickstart is a basic example that demonstrates server side SSL configuration in {productName}.
@@ -17,6 +11,7 @@ The `helloworld-ssl` quickstart is a basic example that demonstrates server side
 :standalone-server-type: default
 :archiveType: war
 :includes-cli-scripts:
+:restoreScriptName: restore-configuration.cli
 
 == What is it?
 
@@ -26,16 +21,9 @@ This quickstart shows how to configure {productName} to enable TLS/SSL configura
 
 Before you run this example, you must create certificates and configure the server to use SSL.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 [[generate_a_keystore_and_self_signed_certificate]]
@@ -73,18 +61,10 @@ Is CN=localhost, OU=wildfly, O=jboss, L=Raleigh, ST=Carolina, C=US correct?
 +
 Make sure you enter your desired "hostname" for the `first and last name` field, otherwise you might run into issues while permanently accepting this certificate as an exception in some browsers. Chrome does not currently exhibit this issue.
 
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
 
 [[configure_the_server]]
 == Configure the Server
@@ -113,7 +93,6 @@ You should see the following result when you run the script:
 The batch executed successfully
 process-state: reload-required
 ----
-
 
 [[test_the_server_ssl_configuration]]
 == Test the Server SSL Configuration
@@ -168,10 +147,7 @@ To test the connection to the SSL port of your your server instance by opening a
 <https-listener name="https" socket-binding="https" ssl-context="qsSSLContext" enable-http2="true"/>
 ----
 
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 [[access_the_application]]
@@ -179,18 +155,9 @@ include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 The application will be running at the following URL: https://localhost:8443/{artifactId}/.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: restore-configuration.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -202,10 +169,7 @@ The batch executed successfully
 process-state: reload-required
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
 
 == Remove the keystore created for this quickstart
@@ -219,18 +183,12 @@ $ cd __{jbossHomeName}__/standalone/configuration/
 
 . Remove the keystore generated for this quickstart.
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
 * Make sure you configure the server by running the JBoss CLI commands as described above under xref:configure_the_server[Configure the Server]. Stop the server at the end of that step.
 * Make sure you xref:restore-the-server-configuration[restore the server configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/helloworld-ws/README.adoc
+++ b/helloworld-ws/README.adoc
@@ -1,15 +1,9 @@
-= helloworld-ws: Hello World JAX-WS Web Service
-:author: Lee Newson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld-ws: Hello World JAX-WS Web Service
+:author: Lee Newson
 :level: Beginner
 :technologies: JAX-WS
-:source: {githubRepoUrl}
 
 [abstract]
 The `helloworld-ws` quickstart demonstrates a simple Hello World application, bundled and deployed as a WAR, that uses JAX-WS to say Hello.
@@ -21,28 +15,13 @@ The `helloworld-ws` quickstart demonstrates a simple Hello World application, bu
 
 The `helloworld-ws` quickstart demonstrates the use of JAX-WS in {productNameFull} as a simple Hello World application.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 Review the server log to see useful information about the deployed web service endpoint.
@@ -63,19 +42,10 @@ JBWS024061: Adding service endpoint metadata: id=org.jboss.as.quickstarts.wshell
 
 You can verify that the Web Service is running and deployed correctly by accessing the following URL: http://localhost:8080/{artifactId}/HelloWorldService?wsdl. This URL will display the deployed WSDL endpoint for the Web Service.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
 
 == Investigate the Console Output
 
@@ -96,23 +66,11 @@ Running org.jboss.as.quickstarts.wshelloworld.ClientArqTest
 Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.988 sec
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
 When you deploy this quickstart, you are presented with a window that explains there is no user interface for this quickstart and directs you to click on a link to view the WSDL definition. However, the Eclipse browser does not support the display of WSDL definitions. Instead, open an external browser and access the following URL: http://localhost:8080/{artifactId}/HelloWorldService?wsdl. This URL will display the deployed WSDL endpoint for the Web Service.
 
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/helloworld/README.adoc
+++ b/helloworld/README.adoc
@@ -1,15 +1,9 @@
-= helloworld: Helloworld Example
-:author: Pete Muir
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= helloworld: Helloworld Example
+:author: Pete Muir
 :level: Beginner
 :technologies: CDI, Servlet
-:source: {githubRepoUrl}
 
 [abstract]
 The `helloworld` quickstart demonstrates the use of CDI and Servlet 3 and is a good starting point to verify {productName} is configured correctly.
@@ -17,58 +11,58 @@ The `helloworld` quickstart demonstrates the use of CDI and Servlet 3 and is a g
 :standalone-server-type: default
 :archiveType: war
 
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
+
 == What is it?
 
 The `helloworld` quickstart demonstrates the use of _CDI_ and _Servlet 3_ in {productNameFull} {productVersion}.
 
+
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
 
 The application will be running at the following URL: http://localhost:8080/{artifactId}/.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/hibernate/README.adoc
+++ b/hibernate/README.adoc
@@ -1,46 +1,39 @@
-= hibernate: How to Use Hibernate 5 in an Application
-:author: Madhumita Sadhukhan
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= hibernate: How to Use Hibernate 5 in an Application
+:author: Madhumita Sadhukhan
 :level: Intermediate
 :technologies: Hibernate
-:source: {githubRepoUrl}
 
 [abstract]
 The `hibernate` quickstart demonstrates how to use Hibernate ORM 5 API over JPA, using Hibernate-Core and Hibernate Bean Validation, and EJB.
 
 :standalone-server-type: default
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
 The `hibernate` quickstart is based upon the link:../kitchensink/README{outfilesuffix}[kitchensink] example, but demonstrates how to use Hibernate Object/Relational Mapping (ORM) 5 over JPA in {productNameFull}.
 
-This project is setup to allow you to create a compliant Java EE 7 application using JSF, CDI, EJB, JPA , Hibernate-Core and Hibernate Bean Validation. It includes a persistence unit associated with Hibernate session and some sample persistence and transaction code to help you with database access in enterprise Java.
+This project is setup to allow you to create a compliant {javaVersion} application using JSF, CDI, EJB, JPA , Hibernate-Core and Hibernate Bean Validation. It includes a persistence unit associated with Hibernate session and some sample persistence and transaction code to help you with database access in enterprise Java.
 
 //*************************************************
-// Add notes about use in a production environment.
+// Product Release content only
 //*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
+
+ifndef::EAPCDRelease[]
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 == Add the Correct Dependencies
@@ -69,16 +62,9 @@ For example:
 </dependency>
 ----
 
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -95,31 +81,11 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-// Additional JBoss Developer Studio instructions
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
 
 // Additional debug info
@@ -133,3 +99,24 @@ You might see the following message when you run the command. It indicates the s
 [INFO]    antlr:antlr:jar:sources:2.7.7:provided
 ----
 ====
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/hibernate4/README.adoc
+++ b/hibernate4/README.adoc
@@ -1,15 +1,9 @@
-= hibernate4: How to Use Hibernate 4 in an Application
-:author: Madhumita Sadhukhan
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= hibernate4: How to Use Hibernate 4 in an Application
+:author: Madhumita Sadhukhan
 :level: Intermediate
 :technologies: Hibernate 4
-:source: {githubRepoUrl}
 
 [abstract]
 This quickstart performs the same functions as the _hibernate_ quickstart, but uses Hibernate 4 for database access. Compare this quickstart to the _hibernate_ quickstart to see the changes needed to run with Hibernate 5.
@@ -18,7 +12,7 @@ This quickstart performs the same functions as the _hibernate_ quickstart, but u
 
 This quickstart is based upon the kitchensink example, but demonstrates how to use Hibernate ORM 4 over JPA in JBoss WildFly.
 
-This project is setup to allow you to create a compliant Java EE 7 application using JSF 2.2, CDI 1.1, EJB 3.2, JPA 2.1 , Hibernate-Core and Hibernate Bean Validation. It includes a persistence unit associated with Hibernate session and some sample persistence and transaction code to help you with database access in enterprise Java.
+This project is setup to allow you to create a compliant {javaVersion} application using JSF 2.2, CDI 1.1, EJB 3.2, JPA 2.1 , Hibernate-Core and Hibernate Bean Validation. It includes a persistence unit associated with Hibernate session and some sample persistence and transaction code to help you with database access in enterprise Java.
 
 You can compare this quickstart to the `hibernate` quickstart, which uses Hibernate 5, to see the code differences between Hibernate 4 and Hibernate 5.
 

--- a/http-custom-mechanism/README.adoc
+++ b/http-custom-mechanism/README.adoc
@@ -1,15 +1,9 @@
-= http-custom-mechanism: Create a custom HTTP authorization mechanism
-:author: Darran Lofthouse
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= http-custom-mechanism: Create a custom HTTP authorization mechanism
+:author: Darran Lofthouse
 :level: Intermediate
 :technologies: EJB, Security
-:source: {githubRepoUrl}
 
 [abstract]
 The `http-custom-mechanism` quickstart demonstrates how to implement a custom HTTP authentication mechanism that can be registered with Elytron.
@@ -18,6 +12,7 @@ The `http-custom-mechanism` quickstart demonstrates how to implement a custom HT
 :archiveType: war
 :archiveName: {artifactId}-webapp
 :includes-cli-scripts:
+:app-user-groups: Users
 
 == What is it?
 
@@ -61,35 +56,15 @@ You will follow these basic steps to test this quickstart:
 . xref:configure_the_server_to_use_the_custom_module[Configure] the server to override the deployment and use the custom module.
 . xref:test_the_secured_servlet_using_the_custom_mechnism[Test] the secured servlet using the custom mechanism
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
 // Add the Authorized Application User
-//*************************************************
-// == Add the Authorized Application User
-:app-user-groups: Users
 include::../shared-doc/add-application-user.adoc[leveloffset=+1]
-
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 [[configure_the_application_security_domain]]
@@ -111,10 +86,7 @@ You should see the following result.
 {"outcome" => "success"}
 ----
 
-//*************************************************
-// Build and deploy the quickstart JAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 // These messages appear in the server log.
@@ -297,22 +269,11 @@ Current Principal 'quickstartUser'    </p>
 </html>
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 ////
 
 Not how to do curl commands in JBDS
@@ -332,8 +293,5 @@ Enter `clean package wildfly:deploy` for the *Goals* and click *Run*. This deplo
 
 ////
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/inter-app/README.adoc
+++ b/inter-app/README.adoc
@@ -1,15 +1,9 @@
-= inter-app: Communicate Between Two Applications Using EJB and CDI
-:author: Pete Muir
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= inter-app: Communicate Between Two Applications Using EJB and CDI
+:author: Pete Muir
 :level: Advanced
 :technologies: EJB, CDI, JSF
-:source: {githubRepoUrl}
 
 [abstract]
 The `inter-app` quickstart shows you how to use a shared API JAR and an EJB to provide inter-application communication between two WAR deployments.
@@ -48,22 +42,11 @@ a| This project contains the second WAR.
 * It exposes an EJB singleton and a simple UI that allows you to read the value set on the bean in `appA`.
 |===
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 == Build and Deploy the Quickstart
@@ -112,10 +95,7 @@ $ mvn wildfly:undeploy -pl appA,appB
 $ mvn wildfly:undeploy -pl shared
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -130,8 +110,5 @@ This quickstart consists of multiple projects containing interdependencies on ea
 . To undeploy the *{artifactId}-app-appB* project, right-click on it and choose *Run As* –>; *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 . To undeploy the `{artifactId}-app-appA` project, right-click on it and choose *Run As* –>; *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/jaxrs-client/README.adoc
+++ b/jaxrs-client/README.adoc
@@ -1,21 +1,19 @@
-= jaxrs-client: JAX-RS Client API example
-:author: Rafael Benevides
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= jaxrs-client: JAX-RS Client API example
+:author: Rafael Benevides
 :level: Beginner
 :technologies: JAX-RS
-:source: {githubRepoUrl}
 
 [abstract]
 The `jaxrs-client` quickstart demonstrates JAX-RS Client API, which interacts with a JAX-RS Web service that runs on {productName}.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -24,33 +22,20 @@ The `jaxrs-client` quickstart demonstrates the JAX-RS Client API which interacts
 This client "calls" many `POST`, `GET`, and `DELETE` operations using different ways: synchronized, asynchronous, delayed and filtered invocations.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+//  System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
 
 
@@ -123,17 +108,9 @@ Results :
 Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -142,14 +119,27 @@ To run the tests in Red Hat JBoss Developer Studio:
 . You must first set the active Maven profile in project properties to be either `arq-managed` for running on managed server or `arq-remote` for running on remote server.
 . Then, to run the tests, right click on the project or individual classes and select Run As –&gt; JUnit Test in the context menu.
 
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
+// Debug the Application
+include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
 
 //*************************************************
-// Add info to debug the application
+// CD Release content only
 //*************************************************
-// == Debug the Application
-include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/jaxrs-jwt/README.adoc
+++ b/jaxrs-jwt/README.adoc
@@ -1,15 +1,9 @@
-= jaxrs-jwt: JAX-RS secured using JSON Web Tokens (JWTs)
-:author: Martin Mazanek
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= jaxrs-jwt: JAX-RS secured using JSON Web Tokens (JWTs)
+:author: Martin Mazanek
 :level: Intermediate
 :technologies: JAX-RS, Security
-:source: {githubRepoUrl}
 
 [abstract]
 The `jaxrs-jwt` quickstart demonstrates a JAX-RS secured application using JSON Web Tokens (JWT) with Elytron.
@@ -32,16 +26,9 @@ There are 4 resource endpoints, plus another one for generating JWTs.
 
 NOTE: This quickstart asserts only few JWT claims for demonstration purposes. In your application, you should use all claims required by the specification you are using.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 [[generate_an_rs256_key_pair]]
@@ -81,16 +68,9 @@ Is CN=localhost, OU=wildfly, O=jboss, L=Raleigh, ST=Carolina, C=US correct?
    [no]:  yes
 ----
 
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 [[configure_the_server]]
@@ -181,10 +161,7 @@ After stopping the server, open the `__{jbossHomeName}__/standalone/configuratio
 </application-security-domains>
 ----
 
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 [[access_the_application]]
@@ -269,16 +246,9 @@ rights to access `/rest/protected`
 
 The endpoint `/rest/claims` demonstrates a way, how you could extract token claims for further manipulation.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
 :restoreScriptName: restore-configuration.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
@@ -291,14 +261,7 @@ The batch executed successfully
 process-state: reload-required
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/jaxws-addressing/README.adoc
+++ b/jaxws-addressing/README.adoc
@@ -1,15 +1,9 @@
-= jaxws-addressing: A WS-addressing JAX-WS Web Service
-:author: R Searls
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= jaxws-addressing: A WS-addressing JAX-WS Web Service
+:author: R Searls
 :level: Beginner
 :technologies: JAX-WS
-:source: {githubRepoUrl}
 
 [abstract]
 The `jaxws-addressing` quickstart is a working example of the web service using WS-Addressing.
@@ -25,34 +19,15 @@ The `jaxws-addressing` quickstart is a working example of the web service using 
 
 The `jaxws-addressing` quickstart demonstrates the use of _JAX-WS_ in {productNameFull} as a simple WS-addressing application.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Install the quickstart parent artifact
-//*************************************************
-// == Install the Quickstart Parent Artifact in Maven
+// Install the Quickstart Parent Artifact in Maven
 include::../shared-doc/install-quickstart-parent-artifact.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -86,17 +61,10 @@ $ mvn exec:java
 Hello World!
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -119,8 +87,5 @@ Hello World!
 
 . To undeploy the project, right-click on the *{artifactId}* parent project and choose *Run As* –> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/jaxws-ejb/README.adoc
+++ b/jaxws-ejb/README.adoc
@@ -1,15 +1,9 @@
-= jaxws-ejb: An EJB JAX-WS Web Service
-:author: R Searls
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= jaxws-ejb: An EJB JAX-WS Web Service
+:author: R Searls
 :level: Beginner
 :technologies: JAX-WS
-:source: {githubRepoUrl}
 
 [abstract]
 The `jaxws-ejb` quickstart is a working example of the web service endpoint created from an EJB.
@@ -25,34 +19,15 @@ The `jaxws-ejb` quickstart is a working example of the web service endpoint crea
 
 The `jaxws-ejb` quickstart demonstrates the use of _JAX-WS_ in {productNameFull} as a simple EJB web service application.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Install the quickstart parent artifact
-//*************************************************
-// == Install the Quickstart Parent Artifact in Maven
+// Install the Quickstart Parent Artifact in Maven
 include::../shared-doc/install-quickstart-parent-artifact.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -86,17 +61,9 @@ $ mvn exec:java
 EJB3Bean returning: ejbClient calling
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -118,10 +85,7 @@ EJB3Bean returning: ejbClient calling
 
 . To undeploy the project, right-click on the *{artifactId}* parent project and choose *Run As* –> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
 
 // Additional debug info

--- a/jaxws-pojo/README.adoc
+++ b/jaxws-pojo/README.adoc
@@ -1,15 +1,9 @@
-= jaxws-pojo: An POJO JAX-WS Web Service
-:author: R Searls
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= jaxws-pojo: An POJO JAX-WS Web Service
+:author: R Searls
 :level: Beginner
 :technologies: JAX-WS
-:source: {githubRepoUrl}
 
 [abstract]
 The `jaxws-pojo` quickstart is a working example of the web service endpoint created from a POJO.
@@ -25,36 +19,16 @@ The `jaxws-pojo` quickstart is a working example of the web service endpoint cre
 
 The `jaxws-pojo` quickstart demonstrates the use of _JAX-WS_ in {productNameFull} as a simple POJO web service application.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Install the quickstart parent artifact
-//*************************************************
-// == Install the Quickstart Parent Artifact in Maven
+// Install the Quickstart Parent Artifact in Maven
 include::../shared-doc/install-quickstart-parent-artifact.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -87,17 +61,9 @@ $ mvn exec:java
 JSEBean pojo: pojoClient calling
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -119,8 +85,5 @@ JSEBean pojo: pojoClient calling
 
 . To undeploy the project, right-click on the *{artifactId}* parent project and choose *Run As* –> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/jaxws-retail/README.adoc
+++ b/jaxws-retail/README.adoc
@@ -1,15 +1,9 @@
-= jaxws-retail: A Retail JAX-WS Web Service
-:author: R Searls
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= jaxws-retail: A Retail JAX-WS Web Service
+:author: R Searls
 :level: Beginner
 :technologies: JAX-WS
-:source: {githubRepoUrl}
 
 [abstract]
 The `jaxws-retail` quickstart is a working example of a simple web service endpoint.
@@ -25,35 +19,15 @@ The `jaxws-retail` quickstart is a working example of a simple web service endpo
 
 The `jaxws-retail` quickstart demonstrates the use of _JAX-WS_ in {productNameFull} as a simple profile management application. It also demonstrates usage of wsconsume to generate classes from WSDL file.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Install the quickstart parent artifact
-//*************************************************
-// == Install the Quickstart Parent Artifact in Maven
+// Install the Quickstart Parent Artifact in Maven
 include::../shared-doc/install-quickstart-parent-artifact.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Server Log: Expected Warnings and Errors
@@ -77,7 +51,6 @@ You might also see the following errors if your Linux environment defines a BASH
 [ERROR] /bin/sh: scl: line 1: syntax error: unexpected end of file
 [ERROR] /bin/sh: error importing function definition for `BASH_FUNC_scl`
 ----
-
 
 == Access the Application
 
@@ -110,17 +83,9 @@ $ mvn exec:java
 Jay Boss's discount is 10.00
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -156,10 +121,7 @@ Jay Boss's discount is 10.00
 ----
 . To undeploy the project, right-click on the *{artifactId}-service* project and choose *Run As* –> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
 
 // Additional debug info

--- a/jsonp/README.adoc
+++ b/jsonp/README.adoc
@@ -1,21 +1,19 @@
-= jsonp: JSON-P Object-based JSON generation and Stream-based JSON consuming
-:author: Rafael Benevides
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= jsonp: JSON-P Object-based JSON generation and Stream-based JSON consuming
+:author: Rafael Benevides
 :level: Beginner
 :technologies: CDI, JSF, JSON-P
-:source: {githubRepoUrl}
 
 [abstract]
 The `jsonp` quickstart demonstrates how to use the JSON-P API to produce object-based structures and then parse and consume them as stream-based JSON strings.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -24,29 +22,19 @@ The `jsonp` quickstart creates a JSON string through object-based JSON generatio
 It shows how to use the JSON-P API to generate, parse, and consume JSON files.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -60,27 +48,31 @@ Note that the JSON string contains String, number, boolean and array values.
 
 . Now, click on the *Parse JSON String using Stream* button. The text area below the button shows the events generated from the parsed JSON string.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/jta-crash-rec/README.adoc
+++ b/jta-crash-rec/README.adoc
@@ -1,21 +1,17 @@
-= jta-crash-rec: Example of JTA Crash Recovery
-:author: Mike Musgrove
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= jta-crash-rec: Example of JTA Crash Recovery
+:author: Mike Musgrove
 :level: Advanced
 :technologies: JTA, Crash Recovery
-:source: {githubRepoUrl}
 
 [abstract]
 The `jta-crash-rec` quickstart uses JTA and Byteman to show how to code distributed (XA) transactions in order to preserve ACID properties on server crash.
 
 :standalone-server-type: full
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
 
 == What is it?
 
@@ -34,24 +30,11 @@ In this example, you halt the {productName} server in the middle of an XA transa
 
 {productName} ships with H2, an in-memory database written in Java. In this example, we use H2 for the database. Although H2 XA support is not recommended for production systems, the example does illustrate the general steps you need to perform for any datasource vendor. This example provides its own H2 XA datasource configuration. It is defined in the `jta-crash-rec-ds.xml` file in the WEB-INF folder of the WAR archive.
 
-//*************************************************
-// Add notes about use in a production environment.
-//*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 == Download and Configure Byteman
@@ -64,16 +47,9 @@ Follow the instructions here to download and configure _Byteman_: link:{configur
 
 _NOTE_: The _Byteman_ scripts only work in JTA mode. They do not work in JTS mode. If you have configured the server for a quickstart that uses JTS, you must follow the quickstart instructions to remove the JTS configuration from the {productName} server before making the following changes. Otherwise _Byteman_ will not halt the server.
 
-//*************************************************
-// Start the server with the full profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -201,25 +177,13 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 
 NOTE: Within JBoss Developer Studio, make sure you define a server runtime environment that uses the `standalone-full.xml` configuration file.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/jts-distributed-crash-rec/README.adoc
+++ b/jts-distributed-crash-rec/README.adoc
@@ -1,15 +1,9 @@
-= jts-distributed-crash-rec: JTS and distributed crash recovery
-:author: Tom Jenkinson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= jts-distributed-crash-rec: JTS and distributed crash recovery
+:author: Tom Jenkinson
 :level: Advanced
 :technologies: JTS, Crash Recovery
-:source: {githubRepoUrl}
 :prerequisites: link:jts/README{outfilesuffix}[jts]
 
 [abstract]
@@ -39,17 +33,9 @@ As an overview, the sequence of events to expect:
 . The user is invited to inspect the content of the transaction objectstore.
 . {productName} server 1 should be restarted. It will then recover the "invoices" delivered to the MDBs, just as it does in the `jts` quickstart.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}_1 and {jbossHomeName}_2
-:requires-multiple-servers:
+// Use of {jbossHomeName}_1 and {jbossHomeName}_2
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 == Download and Configure Byteman
@@ -290,5 +276,5 @@ __{jbossHomeName}_2__/standalone/data/tx-object-store
 //*************************************************
 // Add JBoss Developer Studio instructions
 //*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]

--- a/jts/README.adoc
+++ b/jts/README.adoc
@@ -1,15 +1,9 @@
-= jts: Java Transaction Service - Distributed EJB Transactions
-:author: Tom Jenkinson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= jts: Java Transaction Service - Distributed EJB Transactions
+:author: Tom Jenkinson
 :level: Intermediate
 :technologies: JTS, EJB, JMS
-:source: {githubRepoUrl}
 :prerequisites: link:cmt/README{outfilesuffix}[cmt]
 
 [abstract]
@@ -19,6 +13,8 @@ The `jts` quickstart shows how to use JTS to perform distributed transactions ac
 :archiveType: war
 :requires-multiple-servers:
 :jbds-not-supported:
+:uses-ds-xml:
+:includes-cli-scripts:
 
 == What is it?
 
@@ -49,24 +45,11 @@ Also, while the `cmt` quickstart uses the Java EE container default datasource, 
 
 After you complete this quickstart, you are invited to run through the link:../jts-distributed-crash-rec/README.adoc[jts-distributed-crash-rec] quickstart. The crash recovery quickstart builds upon this quickstart by demonstrating the fault tolerance of {productNameFull}.
 
-//*************************************************
-// Add notes about use in a production environment.
-//*************************************************
-// == Considerations for Use in a Production Environment
-:uses-ds-xml:
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
-:includes-cli-scripts:
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 == Prerequisites
@@ -237,10 +220,7 @@ You will see the following warnings in the server log. You can ignore these warn
 WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in a future version.
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
 
@@ -326,8 +306,6 @@ NOTE: For Windows, use the `__{jbossHomeName}_1__\bin\jboss-cli.bat` script.
 }
 ----
 
-
-
 === Remove the JTS Server Configuration Manually
 
 . Stop the server.
@@ -356,8 +334,5 @@ NOTE: For Windows, use the `__{jbossHomeName}_1__\bin\jboss-cli.bat` script.
 </subsystem>
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]

--- a/kitchensink-angularjs/README.adoc
+++ b/kitchensink-angularjs/README.adoc
@@ -1,82 +1,52 @@
-= kitchensink-angularjs: Demonstrates AngularJS with JAX-RS
-:author: Pete Muir
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= kitchensink-angularjs: Demonstrates AngularJS with JAX-RS
+:author: Pete Muir
 :level: Intermediate
 :technologies: AngularJS, CDI, JPA, EJB, JPA, JAX-RS, BV
-:source: {githubRepoUrl}
 
 [abstract]
-The `kitchensink-angularjs` quickstart demonstrates a Java EE 7 application using AngularJS with JAX-RS, CDI, EJB, JPA, and Bean Validation.
+The `kitchensink-angularjs` quickstart demonstrates a {javaVersion} application using AngularJS with JAX-RS, CDI, EJB, JPA, and Bean Validation.
 
 :standalone-server-type: default
 :archiveType: war
 
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
+
 == What is it?
 
-The `kitchensink-angularjs` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with AngularJS on Java EE 7 with {productNameFull}.
+The `kitchensink-angularjs` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with AngularJS on {javaVersion} with {productNameFull}.
 
-This project is setup to allow you to create a compliant Java EE 7 application using CDI 1.2, EJB 3.2, JPA 2.1 and Bean Validation 1.1. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
+This project is setup to allow you to create a compliant {javaVersion} application using CDI 1.2, EJB 3.2, JPA 2.1 and Bean Validation 1.1. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
 The application will be running at the following URL: http://localhost:8080/{artifactId}/.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Run the Arquillian functional tests
-//*************************************************
-// == Run the Arquillian Functional Tests
+// Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -96,12 +66,6 @@ HTML Problem: Undefined attribute name (ng-submit)
 HTML Problem: Undefined attribute name (ng-view)
 ----
 
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
 == Debug the Application
 
 If you want to debug the source code or look at the Javadocs of any library in the project, run either of the following commands to pull them into your local repository. The IDE should then detect them.
@@ -111,3 +75,24 @@ If you want to debug the source code or look at the Javadocs of any library in t
 $ mvn dependency:sources
 $ mvn dependency:resolve -Dclassifier=javadoc
 ----
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/kitchensink-ear/README.adoc
+++ b/kitchensink-ear/README.adoc
@@ -1,60 +1,34 @@
-= kitchensink-ear: Using Multiple Java EE 7 Technologies Deployed as an EAR
-:author: Pete Muir
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= kitchensink-ear: Using Multiple {javaVersion} Technologies Deployed as an EAR
+:author: Pete Muir
 :level: Intermediate
 :technologies: CDI, JSF, JPA, EJB, JAX-RS, BV, EAR
-:source: {githubRepoUrl}
 
 [abstract]
 The `kitchensink-ear` quickstart demonstrates web-enabled database application, using JSF, CDI, EJB, JPA, and Bean Validation, packaged as an EAR.
 
 :standalone-server-type: default
 :archiveType: ear
+:uses-h2:
+:uses-ds-xml:
 
 == What is it?
 
-The `kitchensink-ear` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with Java EE 7 on {productNameFull}.
+The `kitchensink-ear` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with {javaVersion} on {productNameFull}.
 
-It demonstrates how to create a compliant Java EE 7 application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java. It is based on the link:../kitchensink/README.adoc[kitchensink] quickstart but is packaged as an EAR archive.
+It demonstrates how to create a compliant {javaVersion} application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java. It is based on the link:../kitchensink/README.adoc[kitchensink] quickstart but is packaged as an EAR archive.
 
-//*************************************************
-// Add notes about use in a production environment.
-//*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart EAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -70,16 +44,9 @@ The application will be running at the following URL: http://localhost:8080/kitc
 Registering __YOUR_NAME__
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
 
 
@@ -120,10 +87,7 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -134,8 +98,5 @@ For this quickstart, follow the special instructions to build link:link:{useEcli
 . This starts the server, deploys the application, and opens a browser window that accesses the running application at http://localhost:8080/kitchensink-ear-web.
 . To undeploy the project, right-click on the *{artifactId}-ear* project and choose *Run As* –> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/kitchensink-jsp/README.adoc
+++ b/kitchensink-jsp/README.adoc
@@ -1,60 +1,46 @@
-= kitchensink-jsp: Kitchensink with a JSP (JavaServer Pages) Front End
-:author: Elvadas Nono
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= kitchensink-jsp: Kitchensink with a JSP (JavaServer Pages) Front End
+:author: Elvadas Nono
 :level: Intermediate
 :technologies: JSP, JSTL, CDI, JPA, EJB, JAX-RS, BV
-:source: {githubRepoUrl}
 
 [abstract]
 The `kitchensink-jsp` quickstart demonstrates how to use JSP, JSTL, CDI, EJB, JPA, and Bean Validation in {productName}.
 
 :standalone-server-type: default
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
-The `kitchensink-jsp` quickstart is a deployable Maven 3 project and demonstrates how to create a compliant Java EE 7 application using JSP 2.0, EL 2.0, JSTL 1.2, CDI, EJB, JPA, and Bean Validation in {productNameFull}.
+The `kitchensink-jsp` quickstart is a deployable Maven 3 project and demonstrates how to create a compliant {javaVersion} application using JSP 2.0, EL 2.0, JSTL 1.2, CDI, EJB, JPA, and Bean Validation in {productNameFull}.
 
 This example is based on the link:../kitchensink/README.adoc[kitchensink] quickstart, but recreates the presentation tier using JSP and JSTL instead of JSF features. It reuses all other components from the Member Registration template. It also reuses the persistence unit and some sample persistence and transaction code to help you with database access in enterprise Java.
 
+
 //*************************************************
-// Add notes about use in a production environment.
+// Product Release content only
 //*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
+
+ifndef::EAPCDRelease[]
+
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the application
 
@@ -71,24 +57,11 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -102,15 +75,28 @@ The tag handler class for "c:out" (org.apache.taglibs.standard.tag.rt.core.OutTa
 
 You can ignore this warning as it does not impact building or deploying the quickstart in JBoss Developer Studio. See https://issues.jboss.org/browse/JBIDE-22175[JBIDE-22175] for the latest updates on this issue.
 
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/kitchensink-ml/README.adoc
+++ b/kitchensink-ml/README.adoc
@@ -1,27 +1,27 @@
-= kitchensink-ml: Localized Version of the kitchensink Quickstart
-:author: Sande Gilda
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= kitchensink-ml: Localized Version of the kitchensink Quickstart
+:author: Sande Gilda
 :level: Intermediate
 :technologies: CDI, JSF, JPA, EJB, JAX-RS, BV, i18n, l10n
-:source: {githubRepoUrl}
 
 [abstract]
-The `kitchensink-ml` quickstart demonstrates a localized Java EE 7 compliant application using JSF, CDI, EJB, JPA, and Bean Validation.
+The `kitchensink-ml` quickstart demonstrates a localized {javaVersion} compliant application using JSF, CDI, EJB, JPA, and Bean Validation.
 
 :standalone-server-type: default
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
-The `kitchensink-ml` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with Java EE 7 on {productNameFull}.
+The `kitchensink-ml` quickstart is a deployable Maven 3 project to help you get your foot in the door developing with {javaVersion} on {productNameFull}.
 
-It demonstrates how to create a _localized_ Java EE 7 compliant application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. A localized application is one that supports multiple languages. That is what the _-ml_ suffix denotes in the quickstart name _kitchensink-ml_. This quickstart also includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
+It demonstrates how to create a _localized_ {javaVersion} compliant application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. A localized application is one that supports multiple languages. That is what the _-ml_ suffix denotes in the quickstart name _kitchensink-ml_. This quickstart also includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
 
 This quickstart uses the link:../kitchensink/README{outfilesuffix}[kitchensink] quickstart as its starting point. It has been enhanced to provide localization of labels and messages. A user sets the preferred language choice in the browser and, if the application supports that language, the application web page is rendered in that language. For demonstration purposes, this quickstart has been tranlated into French(fr) and Spanish (es) using http://translate.google.com, so the translations may not be ideal.
 
@@ -112,35 +112,20 @@ FacesMessage m = new FacesMessage(FacesMessage.SEVERITY_INFO,
 How you set your browser preferred locale depends on the browser and version you use. Use your browser help option to search for instructions to change the preferred language setting.
 
 //*************************************************
-// Add notes about use in a production environment.
+// Product Release content only
 //*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
+
+ifndef::EAPCDRelease[]
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -160,34 +145,34 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/kitchensink-utjs-angularjs/README.adoc
+++ b/kitchensink-utjs-angularjs/README.adoc
@@ -1,82 +1,36 @@
-= kitchensink-utjs-angular: Example using Undertow.js with Angular.js on the front end
-:author: Stuart Douglas
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= kitchensink-utjs-angular: Example using Undertow.js with Angular.js on the front end
+:author: Stuart Douglas
 :level: Intermediate
 :technologies: Undertow.js, Angular.js
-:source: {githubRepoUrl}
 
 [abstract]
 Based on kitchensink, but uses a Angular for the front end and Undertow.js for the back end.
 
 == What is it?
 
-This quickstart is a deployable Maven 3 project to help you get your foot in the door developing with Undertow.js and Java EE7 on JBoss WildFly.
+This quickstart is a deployable Maven 3 project to help you get your foot in the door developing with Undertow.js and {javaVersion} on JBoss WildFly.
 
-This project is setup to allow you to create a compliant Java EE 7 application using Undertow.js CDI 1.1, JPA 2.1 and Bean Validation 1.1. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in Undertow.js.
+This project is setup to allow you to create a compliant {javaVersion} application using Undertow.js CDI 1.1, JPA 2.1 and Bean Validation 1.1. It includes a persistence unit and some sample persistence and transaction code to introduce you to database access in Undertow.js.
 
-== System requirements
+// System Requirements
+include::../shared-doc/system-requirements.adoc[leveloffset=+1]
+// Use of {jbossHomeName}
+include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
+// Start the {productName} Standalone Server
+include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
+// Build and Deploy the Quickstart
+include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
-All you need to build this project is ${build.requirements}. See https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONFIGURE_MAVEN_JBOSS_EAP7.md#configure-maven-to-build-and-deploy-the-quickstarts[Configure Maven for ${productName} ${product.version}] to make sure you are configured correctly for testing the quickstarts.
+== Access the application
 
-== Start JBoss WildFly with the Web Profile
+The application will be running at the following URL: http://localhost:8080/{artifactId}/
 
-. Open a command line and navigate to the root of the JBoss server directory.
-. 
-
-The following shows the command line to start the server with the web profile:
-
-[source]
-----
-For Linux:   JBOSS_HOME/bin/standalone.sh
-For Windows: JBOSS_HOME\bin\standalone.bat
-----
-
-== Build and Deploy the Quickstart
-
-_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See https://github.com/jboss-developer/jboss-eap-quickstarts#build-and-deploy-the-quickstarts[Build and Deploy the Quickstarts] for complete instructions and additional options._
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-Type this command to build and deploy the archive:
-
-[source]
-----
-mvn clean package wildfly:deploy
-----
-
-. 
-
-This will deploy `target/${project.artifactId}.war` to the running instance of the server.
-
-Access the application
-———————
-
-The application will be running at the following URL: http://localhost:8080/${project.artifactId}/[http://localhost:8080/${project.artifactId}/].
-
-== Undeploy the Archive
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-When you are finished testing, type this command to undeploy the archive:
-
-[source]
-----
-mvn wildfly:undeploy
-----
-
-== Run the Quickstart in JBoss Developer Studio or Eclipse
-
-You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/USE_JBDS.md[Use JBoss Developer Studio or Eclipse to Run the Quickstarts] 
+// Undeploy the Quickstart
+include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application
 

--- a/kitchensink-utjs-mustache/README.adoc
+++ b/kitchensink-utjs-mustache/README.adoc
@@ -1,18 +1,15 @@
-= kitchensink-utjs-angular: Example using Undertow.js with Mutache templates
-:author: Stuart Douglas
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= kitchensink-utjs-angular: Example using Undertow.js with Mutache templates
+:author: Stuart Douglas
 :level: Intermediate
 :technologies: Undertow.js, Mustache
-:source: {githubRepoUrl}
 
 [abstract]
 Based on kitchensink, but uses Mustache for the front end and Undertow.js for the back end.
+
+:standalone-server-type: default
+:archiveType: war
 
 == What is it?
 
@@ -20,69 +17,23 @@ This quickstart is a deployable Maven 3 project to help you get your foot in the
 
 This project is 100% JavaScript, it does not contain any Java code.
 
-== System requirements
+// System Requirements
+include::../shared-doc/system-requirements.adoc[leveloffset=+1]
+// Use of {jbossHomeName}
+include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
+// Start the {productName} Standalone Server
+include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
+// Build and Deploy the Quickstart
+include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
-The application this project produces is designed to be run on ${product.name.full} ${product.version} or later.
+== Access the application
 
-All you need to build this project is ${build.requirements}. See https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONFIGURE_MAVEN_JBOSS_EAP7.md#configure-maven-to-build-and-deploy-the-quickstarts[Configure Maven for ${productName} ${product.version}] to make sure you are configured correctly for testing the quickstarts.
+The application will be running at the following URL: http://localhost:8080/{artifactId}/
 
-== Configure Maven
-
-If you have not yet done so, you must https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONFIGURE_MAVEN.md[Configure Maven] before testing the quickstarts.
-
-== Start JBoss WildFly with the Web Profile
-
-. Open a command line and navigate to the root of the JBoss server directory.
-. 
-
-The following shows the command line to start the server with the web profile:
-
-[source]
-----
-For Linux:   JBOSS_HOME/bin/standalone.sh
-For Windows: JBOSS_HOME\bin\standalone.bat
-----
-
-== Build and Deploy the Quickstart
-
-_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See https://github.com/jboss-developer/jboss-eap-quickstarts#build-and-deploy-the-quickstarts[Build and Deploy the Quickstarts] for complete instructions and additional options._
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-Type this command to build and deploy the archive:
-
-[source]
-----
-mvn clean package wildfly:deploy
-----
-
-. 
-
-This will deploy `target/${project.artifactId}.war` to the running instance of the server.
-
-Access the application
-———————
-
-The application will be running at the following URL: http://localhost:8080/${project.artifactId}/[http://localhost:8080/${project.artifactId}/].
-
-== Undeploy the Archive
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-When you are finished testing, type this command to undeploy the archive:
-
-[source]
-----
-mvn wildfly:undeploy
-----
-
-== Run the Quickstart in JBoss Developer Studio or Eclipse
-
-You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/USE_JBDS.md[Use JBoss Developer Studio or Eclipse to Run the Quickstarts] 
+// Undeploy the Quickstart
+include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application
 

--- a/kitchensink/README.adoc
+++ b/kitchensink/README.adoc
@@ -1,58 +1,43 @@
-= kitchensink: Assortment of technologies including Arquillian
-:author: Pete Muir
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= kitchensink: Assortment of technologies including Arquillian
+:author: Pete Muir
 :level: Intermediate
 :technologies: CDI, JSF, JPA, EJB, JAX-RS, BV
-:source: {githubRepoUrl}
 
 [abstract]
-The `kitchensink` quickstart demonstrates a Java EE 7 web-enabled database application using JSF, CDI, EJB, JPA, and Bean Validation.
+The `kitchensink` quickstart demonstrates a {javaVersion} web-enabled database application using JSF, CDI, EJB, JPA, and Bean Validation.
 
 :standalone-server-type: default
 :archiveType: war
 :uses-h2:
 :uses-ds-xml:
 
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
+
 == What is it?
 
-The `kitchensink` quickstart is a deployable Maven 3 project designed to help you get your foot in the door developing with Java EE 7 on {productNameFull}.
+The `kitchensink` quickstart is a deployable Maven 3 project designed to help you get your foot in the door developing with {javaVersion} on {productNameFull}.
 
-It demonstrates how to create a compliant Java EE 7 application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. It also includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
+It demonstrates how to create a compliant {javaVersion} application using JSF, CDI, JAX-RS, EJB, JPA, and Bean Validation. It also includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java.
 
 //*************************************************
-// Add notes about use in a production environment.
+// Product Release content only
 //*************************************************
-// == Considerations for Use in a Production Environment
+
+ifndef::EAPCDRelease[]
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+//  Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+//  Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+//  Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -70,32 +55,33 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+//  Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/logging-tools/README.adoc
+++ b/logging-tools/README.adoc
@@ -1,21 +1,19 @@
-= logging-tools: Internationalization and Localization with JBoss Logging Tools
-:author: Darrin Mison
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= logging-tools: Internationalization and Localization with JBoss Logging Tools
+:author: Darrin Mison
 :level: Beginner
 :technologies: JBoss Logging Tools
-:source: {githubRepoUrl}
 
 [abstract]
 The `logging-tools` quickstart shows how to use JBoss Logging Tools to create internationalized loggers, exceptions, and messages and localize them.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -25,16 +23,16 @@ Once the quick start is deployed you can access it using URLs documented below.
 
 Instructions are included below for starting {productName} with a different locale than the system default.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
-include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 
 //*************************************************
-// Add Use of JBoss Home Name
+// Product Release content only
 //*************************************************
-// == Use of {jbossHomeName}
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
+include::../shared-doc/system-requirements.adoc[leveloffset=+1]
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 == Configure the Server to Start With a Different Locale (Optional)
@@ -60,19 +58,10 @@ JAVA_OPTS="$JAVA_OPTS -Duser.country=DE -Duser.language=de"
 
 For more information about internationalization and localization, see http://www.oracle.com/technetwork/java/javase/tech/intl-139810.html.
 
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -112,17 +101,9 @@ Note that `WebApplicationException` cannot be directly localized by JBoss Loggin
 *** Logs a localized message with the localized exception as the cause
 *** Throws a `WebApplicationException`(400) with the text from the localized `ParseException`
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -136,14 +117,27 @@ GreeterExceptionBundle_$bundle.java
 Java Problem
 ----
 
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
+// Debug the Application
+include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
 
 //*************************************************
-// Add info to debug the application
+// CD Release content only
 //*************************************************
-// == Debug the Application
-include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/logging/README.adoc
+++ b/logging/README.adoc
@@ -1,15 +1,9 @@
-= logging: Example That Sets Up Different Logging Levels
-:author: Joel Tosi
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= logging: Example That Sets Up Different Logging Levels
+:author: Joel Tosi
 :level: Intermediate
 :technologies: Logging
-:source: {githubRepoUrl}
 
 [abstract]
 The `logging` quickstart demonstrates how to configure different logging levels in {productName}. It also includes an asynchronous logging example.
@@ -17,6 +11,7 @@ The `logging` quickstart demonstrates how to configure different logging levels 
 :standalone-server-type: default
 :archiveType: war
 :includes-cli-scripts:
+:restoreScriptName: remove-logging.cli
 
 == What is it?
 
@@ -26,34 +21,15 @@ This quickstart contains just one class file and one JSP file. When you access t
 
 To better visualize how the logging configuration works, you first deploy and access the application before configuring the logs and view the resulting log files. Then you configure the logs, redeploy and access the application, and look at the log files again to see the differences.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 [[access_the_application]]
@@ -243,18 +219,9 @@ TRACE - Turned on in any environment where you are trying to follow an execution
 . To view log file differences for different logging levels, change the level for the "org.jboss.as.quickstarts.logging" logger
 from TRACE to DEBUG, INFO, WARN, ERROR, or FATAL, then access the application.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: remove-logging.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -265,25 +232,14 @@ This script removes the log and file handlers from the `logging` subsystem in th
 The batch executed successfully
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
 * Make sure you configure {productName} server logging as described above under xref:configure_the_server[Configure the Server]. Stop the server at the end of that step.
 * Make sure you xref:remove_the_logging_configuration[Remove the Logging Configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/mail/README.adoc
+++ b/mail/README.adoc
@@ -1,15 +1,9 @@
-= mail: E-Mail Example using CDI and JSF
-:author: Joel Tosi
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= mail: E-Mail Example using CDI and JSF
+:author: Joel Tosi
 :level: Beginner
 :technologies: JavaMail, CDI, JSF
-:source: {githubRepoUrl}
 
 [abstract]
 The `mail` quickstart demonstrates how to send email using CDI and JSF and the default Mail provider that ships with {productName}.
@@ -17,6 +11,7 @@ The `mail` quickstart demonstrates how to send email using CDI and JSF and the d
 :standalone-server-type: default
 :archiveType: war
 :includes-cli-scripts:
+:restoreScriptName: remove-mail-session.cli
 
 == What is it?
 
@@ -28,16 +23,9 @@ You can use the default mail provider that comes out of the box with {productNam
 
 This example is a web application that takes `To`, `From`, `Subject`, and `Message Body` input and sends mail to that address. The front end is a JSF page with a simple POJO backing, leveraging CDI for resource injection.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 [[configure_an_smtp_server_on_your_local_machine]]
@@ -48,18 +36,10 @@ To configure an SMTP mail server, consult the documentation for your operating s
 
 If you do not configure an SMTP mail server on your local machine, you will see the exception `com.sun.mail.util.MailConnectException:  Couldn&#39;t connect to host, port: localhost, 25; timeout -1;` when you access the application and attempt to send an email.
 
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
 
 [[configure_the_server]]
 == Configure the Server
@@ -131,12 +111,8 @@ The `MyOtherMail` mail session is added to the `mail` subsystem and configured t
   </subsystem>
 ----
 
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -144,18 +120,9 @@ The application will be running at the following URL: http://localhost:8080/{art
 
 NOTE: If you see `Error processing request` in the browser when you access the application and attempt to send email, followed by `javax.servlet.ServletException: com.sun.mail.util.MailConnectException: Couldn&#39;t connect to host, port: localhost, 25; timeout -1; nested exception is: java.net.ConnectException: Connction refused`, make sure you followed the instructions above to xref:configure_an_smtp_server_on_your_local_machine[Configure an SMTP Server on Your Local Machine].
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: remove-mail-session.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -167,16 +134,9 @@ The batch executed successfully
 process-state: reload-required
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -186,8 +146,5 @@ include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[levelof
 * To undeploy the project, right-click on the *{artifactId}* project and choose *Run As* –&gt; *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 * Make sure you xref:restore_the_server_configuration[restore the {productName} server configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/managed-executor-service/README.adoc
+++ b/managed-executor-service/README.adoc
@@ -1,21 +1,21 @@
-= managed-executor-service: Managed Executor Service example
-:author: Rafael Benevides
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= managed-executor-service: Managed Executor Service example
+:author: Rafael Benevides
 :level: Beginner
 :technologies: EE Concurrency Utilities, JAX-RS, JAX-RS Client API
-:source: {githubRepoUrl}
 
 [abstract]
 The `managed-executor-service` quickstart demonstrates how Java EE applications can submit tasks for asynchronous execution.
 
 :standalone-server-type: default
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -27,38 +27,23 @@ A JAX-RS resource provides access to some operations that are executed asynchron
 
 This quickstart does not contain any user interface. The tests must be run to verify everything is working correctly.
 
+
 //*************************************************
-// Add notes about use in a production environment.
+// Product Release content only
 //*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
+
+ifndef::EAPCDRelease[]
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
 
 == Investigate the Console Output
 
@@ -134,10 +119,7 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -148,14 +130,26 @@ To run the tests in Red Hat JBoss Developer Studio, you must first set the activ
 
 Then, to run the tests, right click on the project or individual classes and select *Run As* –> *JUnit Test* in the context menu.
 
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
+// Debug the Application
+include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
 
 //*************************************************
-// Add info to debug the application
+// CD Release content only
 //*************************************************
-// == Debug the Application
-include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/messaging-clustering-singleton/README.adoc
+++ b/messaging-clustering-singleton/README.adoc
@@ -1,15 +1,9 @@
-= messaging-clustering-singleton: Messaging Example that Demonstrates Clustering
-:author: Flavia Rainone, Jess Sightler
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= messaging-clustering-singleton: Messaging Example that Demonstrates Clustering
+:author: Flavia Rainone, Jess Sightler
 :level: Advanced
 :technologies: JMS, MDB, Clustering
-:source: {githubRepoUrl}
 
 [abstract]
 The `messaging-clustering-singleton` quickstart uses a JMS topic and a queue to demonstrate clustering using {productName} messaging with MDB singleton configuration where only one node in the cluster will be active.
@@ -55,16 +49,9 @@ Here, you can see that only one of the MDBs, `HelloWorldTopicMDB`, is associated
 
 If a delivery group is used in conjunction with singleton, as is the case of this quickstart, the MDB will be active in the singleton provider node only if that node has `delivery-group` enabled. If not, the MDB will be inactive in that node and all remainder nodes of the cluster.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 == Build the Project
@@ -88,16 +75,9 @@ You can choose to configure and deploy this quickstart to a xref:configure_the_s
 
 You configure the server by running the `install-domain.cli` script provided in the root directory of this quickstart.
 
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Managed Domain Configuration
+// Back Up the {productName} Managed Domain Configuration
 include::../shared-doc/back-up-managed-domain-configuration.adoc[leveloffset=+3]
-
-//*************************************************
-// Start the managed domain
-//*************************************************
-// ==== Start the {productName} Managed Domain
+// Start the {productName} Managed Domain
 include::../shared-doc/start-the-managed-domain.adoc[leveloffset=+3]
 
 ==== Configure the Domain Server and Deploy the Quickstart Using the JBoss CLI
@@ -149,16 +129,9 @@ If you choose to use standalone servers rather than a managed domain, you need t
 
 Since both application servers must be configured in the same way, you must configure the first server and then clone it.
 
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+3]
-
-//*************************************************
-// Start the server with the full HA profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+3]
 
 ==== Configure the Standalone Server and Deploy the Quickstart Using the JBoss CLI
@@ -499,8 +472,5 @@ The batch executed successfully
 . If it is running, stop the second instance of the {productName} server.
 . Delete the cloned directory.
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]

--- a/messaging-clustering/README.adoc
+++ b/messaging-clustering/README.adoc
@@ -1,15 +1,9 @@
-= messaging-clustering: Messaging Example that Demonstrates Clustering
-:author: Jess Sightler
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= messaging-clustering: Messaging Example that Demonstrates Clustering
+:author: Jess Sightler
 :level: Intermediate
 :technologies: JMS, MDB
-:source: {githubRepoUrl}
 :prerequisites: link:helloworld-mdb/README{outfilesuffix}[helloworld-mdb]
 
 [abstract]
@@ -25,16 +19,9 @@ The `messaging-clustering` quickstart does not contain any code and instead uses
 
 The `messaging-clustering` quickstart demonstrates the use of clustering with Apache ActiveMQ and {productNameFull}. It uses the link:../helloworld-mdb/README{outfilesuffix}[helloworld-mdb] quickstart for its tests, so there is no code associated with this quickstart. Instructions are provided to run the quickstart on either a standalone server or in a managed domain.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// = Use of {jbossHomeName}_1 and {jbossHomeName}_2
+// Use of {jbossHomeName}_1 and {jbossHomeName}_2
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 == Prerequisites
@@ -79,10 +66,7 @@ After you have completed testing this quickstart, you can replace these files to
 
 You configure the server by running the install-domain.cli script provided in the root directory of this quickstart.
 
-//*************************************************
-// Start the managed domain
-//*************************************************
-// ==== Start the {productName} Managed Domain
+// Start the {productName} Managed Domain
 include::../shared-doc/start-the-managed-domain.adoc[leveloffset=+3]
 
 ==== Configure the Domain Server and Deploy the Quickstart Using the JBoss CLI
@@ -364,8 +348,5 @@ The batch executed successfully
 . If it is running, stop the second instance of the {productName} server.
 . Delete the cloned directory.
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]

--- a/numberguess/README.adoc
+++ b/numberguess/README.adoc
@@ -1,15 +1,9 @@
-= numberguess: Example Using CDI and JSF
-:author: Pete Muir
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= numberguess: Example Using CDI and JSF
+:author: Pete Muir
 :level: Beginner
 :technologies: CDI, JSF
-:source: {githubRepoUrl}
 
 [abstract]
 The `numberguess` quickstart demonstrates the use of CDI  (Contexts and Dependency Injection) and JSF (JavaServer Faces) in {productName}.
@@ -17,58 +11,60 @@ The `numberguess` quickstart demonstrates the use of CDI  (Contexts and Dependen
 :standalone-server-type: default
 :archiveType: war
 
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
+
 == What is it?
 
 The `numberguess` quickstart demonstrates the use of CDI (Contexts and Dependency Injection) and JSF (JavaServer Faces) in {productNameFull}.
 
+
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
 
 The application will be running at the following URL: http://localhost:8080/{artifactId}/.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/payment-cdi-event/README.adoc
+++ b/payment-cdi-event/README.adoc
@@ -1,21 +1,19 @@
-= payment-cdi-event: Use CDI Events to Process Debit and Credit Operations
-:author: Elvadas Nono
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= payment-cdi-event: Use CDI Events to Process Debit and Credit Operations
+:author: Elvadas Nono
 :level: Beginner
 :technologies: CDI, JSF
-:source: {githubRepoUrl}
 
 [abstract]
 The `payment-cdi-event` quickstart demonstrates how to create credit and debit CDI Events in {productName}, using a JSF front-end client.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -49,55 +47,50 @@ The `payment-cdi-event` quickstart defines the following classes and interfaces:
 ** The payment handler exposes the list of events caught during a session (`@Named` `name=payments`).
 * The `resources` package contains the `Resources` class that produces the logger for the application.
 
+
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
 
 The application will be running at the following URL: http://localhost:8080/{artifactId}/.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <version.spring.framework>4.3.14.RELEASE</version.spring.framework>
         <!-- EAP component version management BOM -->
         <version.server.bom>14.0.0.Beta1-SNAPSHOT</version.server.bom>
-        
+
         <version.jaxws-tools-maven-plugin>1.2.2.Final</version.jaxws-tools-maven-plugin>
 
         <!-- Other dependency versions -->
@@ -540,7 +540,7 @@
                 <module>spring-kitchensink-springmvctest/functional-tests</module>
             </modules>
         </profile>
-      
+
         <profile>
             <!-- An optional Arquillian testing profile that executes tests in your JBoss EAP instance.
                  This profile will start a new JBoss EAP instance, and execute the test, shutting it down when done.
@@ -638,7 +638,6 @@
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctor-maven-plugin</artifactId>
                         <version>1.5.6</version>
-                        <inherited>false</inherited>
                         <configuration>
                             <backend>html5</backend>
                             <attributes>

--- a/resteasy-jaxrs-client/README.adoc
+++ b/resteasy-jaxrs-client/README.adoc
@@ -1,15 +1,9 @@
-= resteasy-jaxrs-client: External JAX-RS Client
-:author: Blaine Mincey
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= resteasy-jaxrs-client: External JAX-RS Client
+:author: Blaine Mincey
 :level: Intermediate
 :technologies: JAX-RS, CDI
-:source: {githubRepoUrl}
 :prerequisites: link:helloworld-rs/README{outfilesuffix}[helloworld-rs]
 
 [abstract]
@@ -24,16 +18,9 @@ The `resteasy-jaxrs-client` quickstart demonstrates an external JAX-RS RestEasy 
 
 This client "calls" the HelloWorld JAX-RS Web Service that was created in the link:../helloworld-rs/README.adoc[helloworld-rs] quickstart. See the *Prerequisite* section below for details on how to build and deploy the link:../helloworld-rs/README.adoc[helloworld-rs] quickstart.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 [[prerequisites]]
@@ -84,10 +71,7 @@ MediaType: application/json
 ===============================================
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions

--- a/security-domain-to-domain/README.adoc
+++ b/security-domain-to-domain/README.adoc
@@ -1,18 +1,19 @@
-= security-domain-to-domain: Identity propagation to an EJB using different security domains
-:author: Darran Lofthouse
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= security-domain-to-domain: Identity propagation to an EJB using different security domains
+:author: Darran Lofthouse
 :level: Advanced
 :technologies: Servlet, EJB, Security
-:source: {githubRepoUrl}
 
 [abstract]
 The `security-domain-to-domain` quickstart demonstrates the propagation of an identity across two different deployments using different security domains.
+
+:standalone-server-type: default
+:archiveType: war
+:uses-h2:
+:includes-cli-scripts:
+:restoreScriptName: restore-configuration.cli
+
 
 == What is it?
 
@@ -22,92 +23,86 @@ When you deploy this example, one user is automatically created for you: user `q
 
 This quickstart takes the following steps to implement Servlet security:
 
-. Web Application:
-** Adds a security constraint to the Servlet using the `@ServletSecurity` and `@HttpConstraint` annotations.
-** Adds a security domain reference to `WEB-INF/jboss-web.xml`.
-** Adds a `login-config` that sets the `auth-method` to `BASIC` in the `WEB-INF/web.xml`.
-* EJB Application
-** Adds a security domain reference using the @org.jboss.ejb3.annotation.SecurityDomain annotation.
-* Application Server (`standalone.xml`):
-** Defines a security domain in the `elytron` subsystem that uses the JDBC security realm to obtain the security data used to authenticate and authorize users.
-** Defined a second security domain in the `elytron` subsystem similar to the first but with different role mappings.
-** Defines an `http-authentication-factory` in the `elytron` subsystem that uses the security domain created in step 1 for BASIC authentication.
-** Adds an `application-security-domain` mapping in the `undertow` subsystem to map the Servlet security domain to the HTTP authentication factory defined in step 3.
-** Adds an `application-security-domain` mapping in the `ejb3` subystem to map the EJBs security domain to the security domain defined in step 2.
-* 
+Web Application::
 
-Database Configuration:
+* Adds a security constraint to the Servlet using the `@ServletSecurity` and `@HttpConstraint` annotations.
+* Adds a security domain reference to `WEB-INF/jboss-web.xml`.
+* Adds a `login-config` that sets the `auth-method` to `BASIC` in the `WEB-INF/web.xml`.
 
-** Adds an application user with access rights to the application.
+EJB Application::
+
+* Adds a security domain reference using the @org.jboss.ejb3.annotation.SecurityDomain annotation.
+
+Application Server (`standalone.xml`)::
+
+* Defines a security domain in the `elytron` subsystem that uses the JDBC security realm to obtain the security data used to authenticate and authorize users.
+* Defined a second security domain in the `elytron` subsystem similar to the first but with different role mappings.
+* Defines an `http-authentication-factory` in the `elytron` subsystem that uses the security domain created in step 1 for BASIC authentication.
+* Adds an `application-security-domain` mapping in the `undertow` subsystem to map the Servlet security domain to the HTTP authentication factory defined in step 3.
+* Adds an `application-security-domain` mapping in the `ejb3` subystem to map the EJBs security domain to the security domain defined in step 2.
+Database Configuration::
+
+* Adds an application user with access rights to the application.
++
 [source]
 ----
 User Name: quickstartUser
 Password: quickstartPwd1!
 ----
++
+When used with the `entry-domain`, this user will have the role `Users`. When used with the `business-domain`, this user will have the role `Manager`.
+
+// System Requirements
+include::../shared-doc/system-requirements.adoc[leveloffset=+1]
+//  Use of {jbossHomeName}
+include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
+
+// Additional add user instructions
 
 When used with the `entry-domain` this will have the role `Users`, when used with the `business-domain` this will have the role `Manager`.
 
-NOTE: This quickstart uses the H2 database included with ${product.name.full} ${product.version}. It is a lightweight, relational example datasource that is used for examples only. It is not robust or scalable, is not supported, and should NOT be used in a production environment!_
+// Back Up the {productName} Standalone Server Configuration
+include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
+// Start the {productName} Standalone Server
+include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
-== System Requirements
-
-The application this project produces is designed to be run on ${product.name.full} ${product.version} or later.
-
-All you need to build this project is ${build.requirements}. See https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONFIGURE_MAVEN_JBOSS_EAP7.md#configure-maven-to-build-and-deploy-the-quickstarts[Configure Maven for ${productName} ${product.version}] to make sure you are configured correctly for testing the quickstarts.
-
-== Use of {jbossHomeName}
-
-In the following instructions, replace `{jbossHomeName}` with the actual path to your ${productName} installation. The installation path is described in detail here: https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/USE_OF_{jbossHomeName}.md#use-of-eap_home-and-jboss_home-variables[Use of {jbossHomeName} and JBOSS_HOME Variables].
-
-== Configure the Server
+[[configure_the_server]]
+== Configure the {productName} Server
 
 You can configure the server by running JBoss CLI commands. For your convenience, this quickstart batches the commands into a `configure-server.cli` script provided in the root directory of this quickstart.
 
-. 
+. Before you begin, make sure you do the following:
 
-Before you begin, back up your server configuration file
+* xref:back_up_standalone_server_configuration[Back up the {productName} standalone server configuration] as described above.
+* xref:start_the_eap_standalone_server[Start the {productName} server] with the standalone default profile as described above.
 
-** If it is running, stop the ${productName} server.
-** Back up the file: `{jbossHomeName}/standalone/configuration/standalone.xml`
-** After you have completed testing this quickstart, you can replace this file to restore the server to its original configuration.
-* 
-
-Start the ${productName} server by typing the following:
-
-[source]
+. Review the `configure-server.cli` file in the root of this quickstart directory. This script adds security domain and HTTP authentication factory to the `elytron` subsystem in the server configuration and also configures the `undertow` subsystem to use the configured HTTP authentication factory for the Web application.
+. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing {jbossHomeName} with the path to your server:
++
+[source,subs="+quotes,attributes+",options="nowrap"]
 ----
-For Linux:  {jbossHomeName}/bin/standalone.sh
-For Windows:  {jbossHomeName}\bin\standalone.bat
+$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=configure-server.cli
 ----
-
-* Review the `configure-server.cli` file in the root of this quickstart directory. This script adds security domain and HTTP authentication factory to the `elytron` subsystem in the server configuration and also configures the `undertow` subsystem to use the configured HTTP authentication factory for the Web application.
-* 
-
-Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing {jbossHomeName} with the path to your server:
-
-[source]
-----
-For Linux: {jbossHomeName}/bin/jboss-cli.sh --connect --file=configure-server.cli
-For Windows: {jbossHomeName}\bin\jboss-cli.bat --connect --file=configure-server.cli
-----
++
+NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat` script.
++
 
 You should see the following result when you run the script:
++
 [source]
 ----
 The batch executed successfully
 ----
 
-* Stop the ${productName} server.
+. Stop the {productName} server.
 
 == Review the Modified Server Configuration
 
 After stopping the server, open the `{jbossHomeName}/standalone/configuration/standalone.xml` file and review the changes.
 
-. 
-
-The following datasource was added to the `datasources` subsystem.
-
-[source]
+. The following datasource was added to the `datasources` subsystem.
++
+[source,xml,options="nowrap"]
 ----
 <datasource jndi-name="java:jboss/datasources/SecurityDomainToDomainDS" pool-name="SecurityDomainToDomainDS">
     <connection-url>jdbc:h2:mem:servlet-security;DB_CLOSE_ON_EXIT=FALSE</connection-url>
@@ -119,11 +114,9 @@ The following datasource was added to the `datasources` subsystem.
 </datasource>
 ----
 
-. 
-
-The following security realms were added to the `elytron` subsystem.
-
-[source, xml]
+. The following security realms were added to the `elytron` subsystem.
++
+[source,xml,options="nowrap"]
 ----
 <jdbc-realm name="entry-realm">
     <principal-query sql="SELECT PASSWORD FROM USERS WHERE USERNAME = ?" data-source="SecurityDomainToDomainDS">
@@ -137,9 +130,10 @@ The following security realms were added to the `elytron` subsystem.
 </jdbc-realm>
 ----
 
-The `entry-realm` security realm is responsible for verifying the credentials for a given principal and for obtaining security attributes (like roles) that are associated with the authenticated identity.
-
+. The `entry-realm` security realm is responsible for verifying the credentials for a given principal and for obtaining security attributes (like roles) that are associated with the authenticated identity.
++
 [source, xml]
+[source,xml,options="nowrap"]
 ----
 <jdbc-realm name="business-realm">
     <principal-query sql="SELECT PASSWORD FROM USERS WHERE USERNAME = ?" data-source="SecurityDomainToDomainDS">
@@ -153,24 +147,20 @@ The `entry-realm` security realm is responsible for verifying the credentials fo
 </jdbc-realm>
 ----
 
-The `business-realm` security realm is just used for loading the identity as it accesses the EJB.
+. The `business-realm` security realm is just used for loading the identity as it accesses the EJB.
 
-. 
-
-The following `role-decoder` was added to the `elytron` subsystem.
-
-[source, xml]
+. The following `role-decoder` was added to the `elytron` subsystem.
++
+[source,xml,options="nowrap"]
 ----
 <simple-role-decoder name="from-roles-attribute" attribute="roles"/>
 ----
-
++
 The realms in this quickstart store the roles associated with a principal in an attribute named roles. Other realms might use different attributes for roles (such as `group`). The purpose of a `role-decoder` is to instruct the security domain how roles are to be retrieved from an authorized identity.
 
-. 
-
-The following security domains were added to the `elytron` subsystem.
-
-[source, xml]
+. The following security domains were added to the `elytron` subsystem.
++
+[source,xml,options="nowrap"]
 ----
 <security-domain name="entry-security-domain" default-realm="entry-realm" permission-mapper="default-permission-mapper" outflow-security-domains="business-security-domain">
     <realm name="entry-realm" role-decoder="from-roles-attribute"/>
@@ -179,15 +169,13 @@ The following security domains were added to the `elytron` subsystem.
 <security-domain name="business-security-domain" default-realm="business-realm" trusted-security-domains="entry-security-domain">
     <realm name="business-realm" role-decoder="from-roles-attribute"/>
 </security-domain>
-
-The `entry-security-domain` is configured to automatically outflow any identities to the `business-security-domain` and in return the `business-security-domain` is configured to trust any identities coming from the `entry-security-domain`. 
 ----
++
+The `entry-security-domain` is configured to automatically outflow any identities to the `business-security-domain` and in return the `business-security-domain` is configured to trust any identities coming from the `entry-security-domain`.
 
-. 
-
-The following `http-authentication-factory` was added to the `elytron` subsystem.
-
-[source, xml]
+. The following `http-authentication-factory` was added to the `elytron` subsystem.
++
+[source,xml,options="nowrap"]
 ----
 <http-authentication-factory name="security-domain-to-domain-http" security-domain="entry-security-domain" http-server-mechanism-factory="global">
     <mechanism-configuration>
@@ -197,72 +185,45 @@ The following `http-authentication-factory` was added to the `elytron` subsystem
     </mechanism-configuration>
 </http-authentication-factory>
 ----
-
++
 It basically defines an HTTP authentication factory for the BASIC mechanism that relies on the `entry-security-domain` security domain to authenticate and authorize access to Web applications.
 
-. 
-
-The following `application-security-domain` was added to the `undertow` subsystem.
-
-[source, xml]
+. The following `application-security-domain` was added to the `undertow` subsystem.
++
+[source,xml,options="nowrap"]
 ----
 <application-security-domains>
     <application-security-domain name="EntryDomain" http-authentication-factory="security-domain-to-domain-http"/>
 </application-security-domains>
 ----
-
++
 This configuration tells `Undertow` that applications with the `EntryDomain` security domain, as defined in the `jboss-web.xml` or by using the `@SecurityDomain` annotation in the Servlet class, should use the `http-authentication-factory` named `security-domain-to-domain-http`.
 
-7) The following `application-security-domain` was added to the `ejb3` subsystem.
-
-[source, xml]
+. The following `application-security-domain` was added to the `ejb3` subsystem.
++
+[source,xml,options="nowrap"]
 ----
-    <application-security-domains>
-        <application-security-domain name="BusinessDomain" security-domain="business-security-domain"/>
-    </application-security-domains>
+<application-security-domains>
+    <application-security-domain name="BusinessDomain" security-domain="business-security-domain"/>
+</application-security-domains>
 ----
-
++
 This configuration tells `EJB3` that applications with the `BusinessDomain` security domain, as defined in the `jboss.xml` or by using the `@SecurityDomain` annotation in the EJB class, should use the `security-domain` named `business-security-domain`.
 
-== Start the Server
+. When you have finished reviewing the configuration changes, xref:start_the_eap_standalone_server[start the {productName} server] with the standalone default profile as described above before you build and deploy the quickstart.
 
-. Open a command prompt and navigate to the root of the ${productName} directory.
-. 
-
-The following shows the command line to start the server:
-
-[source]
-----
-For Linux:   {jbossHomeName}/bin/standalone.sh
-For Windows: {jbossHomeName}\bin\standalone.bat
-----
-
-== Build and Deploy the Quickstart
-
-. Make sure you have started the ${productName} server as described above.
-. Open a command prompt and navigate to the root directory of this quickstart.
-. 
-
-Type this command to build and deploy the archive:
-
-[source]
-----
-mvn clean install wildfly:deploy
-----
-
-. 
-
-This will deploy `target/${project.artifactId}.war` to the running instance of the server.
+//  Build and Deploy the Quickstart
+include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
 
-The application will be running at the following URL http://localhost:8080/${project.artifactId}/[http://localhost:8080/${project.artifactId}/].
+The application will be running at the following URL: http://localhost:8080/{artifactId}/
 
 When you access the application, you should get a browser login challenge.
 
 Log in using the username `quickstartUser` and password `quickstartPwd1!`. The browser will display the following security info:
 
-[source]
+[source,options="nowrap"]
 ----
 Successfully called Secured Servlet
 Identity as visible to servlet.
@@ -285,56 +246,28 @@ Caller Has Role 'User'=false
 Caller Has Role 'Manager'=true
 ----
 
-This shows that the user `quickstartUser` calls the servlet and has role `User` but does not have the role `Manager`, as the call reaches the EJB the principal is still `quickstartUser` but now the identity does not have the role `User` and instead has the role `Manager`. 
+This shows that the user `quickstartUser` calls the servlet and has role `User` but does not have the role `Manager`, as the call reaches the EJB the principal is still `quickstartUser` but now the identity does not have the role `User` and instead has the role `Manager`.
 
 == Server Log: Expected Warnings and Errors
 
-_Note:_ You will see the following warning in the server log. You can ignore it.
+You will see the following warning in the server log. You can ignore it.
 
 [source]
 ----
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-== Undeploy the Archive
+// Undeploy the Quickstart
+include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
-. Make sure you have started the ${productName} server as described above.
-. Open a command prompt and navigate to the root directory of this quickstart.
-. 
-
-When you are finished testing, type this command to undeploy the archive:
-
-[source]
-----
-mvn wildfly:undeploy
-----
+// Restore the {productName} Standalone Server Configuration
+include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 == Restore the Server Configuration
 
 You can restore the original server configuration by running the `restore-configuration.cli` script provided in the root directory of this quickstart or by manually restoring the back-up copy the configuration file.
 
-=== Restore the Server Configuration by Running the JBoss CLI Script
-
-. 
-
-Start the ${productName} server by typing the following:
-
-[source]
-----
-For Linux:  {jbossHomeName}/bin/standalone.sh
-For Windows:  {jbossHomeName}\bin\standalone.bat
-----
-
-. 
-
-Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing {jbossHomeName} with the path to your server:
-
-[source]
-----
-For Linux: {jbossHomeName}/bin/jboss-cli.sh --connect --file=restore-configuration.cli
-For Windows: {jbossHomeName}\bin\jboss-cli.bat --connect --file=restore-configuration.cli
-----
-
+// Additional informatin about this script
 This script removes the `application-security-domain` configurations from the `ejb3` and `undertow` subsystem, the `http-authentication-factory`, `security-domain`, `security-realm` and `role-decoder` configuration from the `elytron` subsystem and it also removes the `datasource` used for this quickstart. You should see the following result when you run the script:
 
 [source]
@@ -343,23 +276,15 @@ The batch executed successfully
 process-state: reload-required
 ----
 
-=== Restore the Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
+include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-. If it is running, stop the ${productName} server.
-. Replace the `{jbossHomeName}/standalone/configuration/standalone.xml` file with the back-up copy of the file.
+// Additional JBDS instructions
 
-== Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+* Be sure to configure the server by running the JBoss CLI commands as described above under xref:configure_the_server[Configure the {productName} Server]. Stop the server at the end of that step.
+* Be sure to xref:restore_the_standalone_server_configuration[Restore the Server Configuration] when you have completed testing this quickstart.
 
-You can also start the server and deploy the quickstarts or run the Arquillian tests from Eclipse using JBoss tools. For general information about how to import a quickstart, add a ${productName} server, and build and deploy a quickstart, see link:${use.eclipse.url}[Use JBoss Developer Studio or Eclipse to Run the Quickstarts].
-
-* Be sure to configure the server by running the JBoss CLI commands as described above under link:#configure-the-server[Configure the ${productName} Server]. Stop the server at the end of that step.
-* Be sure to link:#restore-the-server-configuration[Restore the Server Configuration] when you have completed testing this quickstart.
-
-== Debug the Application
-
-If you want to debug the source code of any library in the project, run the following command to pull the source into your local repository. The IDE should then detect it.
-
-[source]
-----
-mvn dependency:sources
-----
+// Debug the Application
+include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/servlet-async/README.adoc
+++ b/servlet-async/README.adoc
@@ -1,21 +1,19 @@
-= servlet-async: How to Write an Asynchronous Servlet
-:author: Christian Sadilek
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= servlet-async: How to Write an Asynchronous Servlet
+:author: Christian Sadilek
 :level: Intermediate
 :technologies: Asynchronous Servlet, CDI, EJB
-:source: {githubRepoUrl}
 
 [abstract]
 The `servlet-async` quickstart demonstrates how to use asynchronous servlets to detach long-running tasks and free up the request processing thread.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -25,56 +23,51 @@ It shows how to detach the execution of a long-running task from the request pro
 
 A long-running task in this context does not refer to a computation intensive task executed on the same machine but could for example be contacting a third-party service that has limited resources or only allows for a limited number of concurrent connections. Moving the calls to this service into a separate and smaller sized thread pool ensures that less threads will be busy interacting with the long-running service and that more requests can be served that do not depend on this service.
 
+
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
 The application will be running at the following URL http://localhost:8080/{artifactId}/.
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/servlet-filterlistener/README.adoc
+++ b/servlet-filterlistener/README.adoc
@@ -1,21 +1,19 @@
-= servlet-filterlistener: How to Write Servlet Filters and Listeners
-:author: Jonathan Fuerth
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= servlet-filterlistener: How to Write Servlet Filters and Listeners
+:author: Jonathan Fuerth
 :level: Intermediate
 :technologies: Servlet Filter, Servlet Listener
-:source: {githubRepoUrl}
 
 [abstract]
 The `servlet-filterlistener` quickstart demonstrates how to use Servlet filters and listeners in an application.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -28,27 +26,18 @@ This example contains the following classes:
 * `ParameterDumpingRequestListener`: A simple servlet request listener that creates a map of the original HTTP request parameter values before the filter is applied.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -100,27 +89,31 @@ INFO  [io.undertow.servlet] (default task-50) VowelRemoverFilter done filtering 
 INFO  [io.undertow.servlet] (default task-50) ParameterDumpingRequestListener: request has been destroyed
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/servlet-security/README.adoc
+++ b/servlet-security/README.adoc
@@ -1,15 +1,9 @@
-= servlet-security:  Using Java EE Declarative Security to Control Servlet Access
-:author: Sherif F. Makary, Pedro Igor, Stefan Guilhen
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= servlet-security:  Using Java EE Declarative Security to Control Servlet Access
+:author: Sherif F. Makary, Pedro Igor, Stefan Guilhen
 :level: Intermediate
 :technologies: Servlet, Security
-:source: {githubRepoUrl}
 
 [abstract]
 The `servlet-security` quickstart demonstrates the use of Java EE declarative security to control access to Servlets and Security in {productName}.
@@ -18,6 +12,7 @@ The `servlet-security` quickstart demonstrates the use of Java EE declarative se
 :archiveType: war
 :uses-h2:
 :includes-cli-scripts:
+:restoreScriptName: restore-configuration.cli
 
 == What is it?
 
@@ -54,34 +49,15 @@ Password: guestPwd1!
 Role: notauthorized
 ----
 
-//*************************************************
-// Add notes about use in a production environment.
-//*************************************************
-// == Considerations for Use in a Production Environment
+//  Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 
@@ -195,12 +171,8 @@ It basically defines an HTTP authentication factory for the BASIC mechanism that
 
 This configuration tells `Undertow` that applications with the `servlet-security-quickstart` security domain, as defined in the `jboss-web.xml` or by using the `@SecurityDomain` annotation in the Servlet class, should use the `http-authentication-factory` named `servlet-security-quickstart-http-auth`. If no `application-security-domain` is defined for a particular security domain, `Undertow` assumes the legacy JAAS based security domains should be used for authentication/authorization and, in this case, the security domain defined in the Web application must match a security domain in the legacy `security` subsystem. The presence of an `application-security-domain` configuration is what enables Elytron authentication for a Web application.
 
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -234,18 +206,10 @@ You will see the following warning in the server log. You can ignore it.
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
-
-//************************************************************
-// Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: restore-configuration.cli
+//  Restore the {productName} Standalone Server Configuration
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -257,24 +221,14 @@ The batch executed successfully
 process-state: reload-required
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
 * Make sure you configure the server by running the JBoss CLI commands as described above under xref:configure_the_server{Configure the Server]. Stop the server at the end of that step.
 * Make sure you xref:restore_the_server_configuration[restore the {productName} server configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/shared-doc/attributes.adoc
+++ b/shared-doc/attributes.adoc
@@ -1,11 +1,94 @@
+//***********************************************************************************
+// Enable the following flag to build README.html files for Product (CD or JBoss EAP) builds.
+// Comment it out to build README.html files for WildFly builds.
+//***********************************************************************************
+:ProductRelease:
+
+//***********************************************************************************
+// Enable the following flag to build README.html files for CD product builds.
+// Comment it out to build README.html files for JBoss EAP product builds.
+//***********************************************************************************
+//:EAPCDRelease:
+
+// Product names and links are dependent on whether it is a product release (CD or JBoss)
+// or the WildFly project.
+// The "DocInfo*" attributes are used to build the book links to the product documentation
+ifdef::ProductRelease[]
+
+ifdef::EAPCDRelease[]
+// EAP CD release
+:productName: JBoss EAP for OpenShift
+:productNameFull: Red Hat JBoss Enterprise Application Platform for OpenShift
+:productVersion: 13
+:githubRepoUrl: https://github.com/jboss-developer/jboss-eap-quickstarts/
+:jbossHomeName: EAP_HOME
+:DocInfoProductNameURL: jboss_enterprise_application_platform_continuous_delivery
+:DocInfoProductName: JBoss Enterprise Application Platform Continuous Delivery
+:DocInfoProductNumber: 13
+:ImageandTemplateImportURL: https://raw.githubusercontent.com/jboss-container-images/jboss-eap-7-openshift-image/eap-cd/templates/
+endif::[]
+
+ifndef::EAPCDRelease[]
+// JBoss EAP release
+:productName: JBoss EAP
+:productNameFull: JBoss Enterprise Application Platform Server
+:productVersion: 7.2.beta
+:githubRepoUrl: https://github.com/jboss-developer/jboss-eap-quickstarts/
+:jbossHomeName: EAP_HOME
+:DocInfoProductName: red_hat_jboss_enterprise_application_platform
+:DocInfoProductNameURL: red_hat_jboss_enterprise_application_platform
+:DocInfoProductNumber: 7.1
+:DocInfoPreviousProductName: jboss-enterprise-application-platform
+:ImageandTemplateImportURL: https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/
+endif::[]
+
+endif::[]
+
+ifndef::ProductRelease[]
+// WildFly project
 :productName: WildFly
 :productNameFull: WildFly Application Server
 :jbossHomeName: WILDFLY_HOME
-:productVersion: 12
+:productVersion: 13
+:githubRepoUrl: https://github.com/wildfly/quickstart/
+:DocInfoProductName: red_hat_jboss_enterprise_application_platform
+:DocInfoProductNameURL: red_hat_jboss_enterprise_application_platform
+:DocInfoProductNumber: 7.1
+:DocInfoPreviousProductName: jboss-enterprise-application-platform
+endif::[]
+
+:source: {githubRepoUrl}
+
+// Attributes for CD releases
+:CDProductName: JBoss Enterprise Application Platform continuous delivery
+:CDProductShortName: {ProductShortName} Continuous Delivery
+:CDProductTitle: JBoss Enterprise Application Platform Continuous Delivery
+:CDProductNameSentence: continuous delivery release for {ProductShortName}
+:CDProductAcronym: JBoss EAP CD
+:CDProductVersion: 13
+:EapForOpenshiftBookName: Red Hat JBoss Enterprise Application Platform for OpenShift
+:EapForOpenshiftOnlineBookName: Red Hat JBoss Enterprise Application Platform for OpenShift Online
+:xpaasproduct: Red Hat JBoss Enterprise Application Platform for OpenShift
+:xpaasproductOpenShiftOnline: Red Hat JBoss Enterprise Application Platform for OpenShift Online
+:xpaasproduct-shortname: JBoss EAP for OpenShift
+:xpaasproductOpenShiftOnline-shortname: JBoss EAP for OpenShift Online
+:EapForOpenshiftBookName: Red Hat JBoss Enterprise Application Platform for OpenShift
+:EapForOpenshiftOnlineBookName: Red Hat JBoss Enterprise Application Platform for OpenShift Online
+:ImagePrefixVersion: eap71
+// OpenShift repository and reference for quickstarts
+:EAPQuickStartRepo: https://github.com/jboss-developer/jboss-eap-quickstarts
+:EAPQuickStartRepoRef: 7.1.0.GA
+// Links to the OpenShift documentation
+:LinkOpenShiftGuide: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/getting_started_with_jboss_eap_for_openshift_container_platform/
+:LinkOpenShiftOnlineGuide: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/getting_started_with_jboss_eap_for_openshift_online/
+
+//*************************
+// Other values
+//*************************
 :ProductShortName: JBoss EAP
 :buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 :jbdsEapServerName: Red Hat JBoss Enterprise Application Platform 7.1
-:githubRepoUrl: https://github.com/wildfly/quickstart/
+:javaVersion: Java EE 7
 :githubRepoBranch: master
 :guidesBaseUrl: https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/
 :useEclipseUrl: {guidesBaseUrl}USE_JBDS.adoc#use_red_hat_jboss_developer_studio_or_eclipse_to_run_the_quickstarts
@@ -36,9 +119,6 @@
 :SingletonSubsystemNamespace: urn:jboss:domain:singleton:1.0
 :TransactionsSubsystemNamespace: urn:jboss:domain:transactions:4.0
 
-:DocInfoProductNameURL: jboss_enterprise_application_platform_continuous_delivery
-:DocInfoProductName: JBoss Enterprise Application Platform continuous delivery
-:DocInfoProductNumber: 12
 
 // LinkProductDocHome: https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/
 :LinkProductDocHome: https://access.redhat.com/documentation/en/jboss-enterprise-application-platform-continuous-delivery

--- a/shared-doc/cd-create-project.adoc
+++ b/shared-doc/cd-create-project.adoc
@@ -1,0 +1,34 @@
+
+[[prepare_openshift_for_quickstart_deployment]]
+= Prepare OpenShift for Quickstart Deployment
+
+. Log in to your OpenShift instance using the `oc login` command.
+. Create a new project for the quickstart in OpenShift. You can create a project in OpenShift using the following command.
++
+[options="nowrap",subs="attributes"]
+----
+$ oc new-project {artifactId}-project
+----
+////
+. Create a keystore.
++
+{xpaasproduct-shortname} requires a keystore to be imported to properly install and configure the image on your OpenShift instance.
++
+[WARNING]
+====
+The following commands generate a self-signed certificate, but for production environments Red Hat recommends that you use your own SSL certificate purchased from a verified Certificate Authority (CA) for SSL-encrypted connections (HTTPS).
+====
++
+You can use the Java `keytool` command to generate a keystore using the following command.
++
+[options="nowrap",subs="attributes"]
+----
+$ keytool -genkey -keyalg RSA -alias {artifactId}-project-selfsigned -keystore keystore.jks -validity 360 -keysize 2048
+----
+. Create a secret from the previously created keystore using the following command.
++
+[options="nowrap",subs="attributes"]
+----
+$ oc secrets new eap7-app-secret keystore.jks
+----
+////

--- a/shared-doc/cd-deploy-project.adoc
+++ b/shared-doc/cd-deploy-project.adoc
@@ -1,0 +1,33 @@
+[[deploy_eap_s2i]]
+= Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+
+. Create a new OpenShift application using the {xpaasproduct-shortname} image and the quickstart's source code. Use the following command to use the `{ImagePrefixVersion}-basic-s2i` template with the `{artifactId}` source code on GitHub.
++
+[options="nowrap",subs="+attributes"]
+----
+oc new-app --template={ImagePrefixVersion}-basic-s2i {backslash}<1>
+ -p IMAGE_STREAM_NAMESPACE="{artifactId}-project" {backslash}<2>
+ -p SOURCE_REPOSITORY_URL="{EAPQuickStartRepo}" {backslash}<3>
+ -p SOURCE_REPOSITORY_REF="{EAPQuickStartRepoRef}" {backslash}<4>
+ -p CONTEXT_DIR="kitchensink"<5>
+----
+<1> The template to use.
+<2> The latest images streams and templates xref:import_imagestreams_templates[were imported into the project's namespace], so you must specify the namespace of where to find the image stream. This is usually the OpenShift project's name.
+<3> URL to the repository containing the application source code.
+<4> The Git repository reference to use for the source code. This can be a Git branch or tag reference.
+<5> The directory within the source repository to build.
++
+NOTE: A template can specify default values for many template parameters, and you might have to override some, or all, of the defaults. To see template information, including a list of parameters and any default values, use the command `oc describe template __TEMPLATE_NAME__`.
+
+. Retrieve the name of the build configuration.
++
+[options="nowrap"]
+----
+$ oc get bc -o name
+----
+. Use the name of the build configuration from the previous step to view the Maven progress of the build.
++
+[options="nowrap",subs="+quotes"]
+----
+$ oc logs -f buildconfig/eap-app
+----

--- a/shared-doc/cd-import-imagestreams-templates.adoc
+++ b/shared-doc/cd-import-imagestreams-templates.adoc
@@ -1,0 +1,42 @@
+
+[[import_imagestreams_templates]]
+= Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+
+Use the following command to import the latest {xpaasproduct-shortname} image streams and templates into your OpenShift project's namespace.
+
+[options="nowrap",subs="+attributes"]
+----
+for resource in \
+  {ImagePrefixVersion}-image-stream.json \
+  {ImagePrefixVersion}-amq-persistent-s2i.json \
+  {ImagePrefixVersion}-amq-s2i.json \
+  {ImagePrefixVersion}-basic-s2i.json \
+  {ImagePrefixVersion}-https-s2i.json \
+  {ImagePrefixVersion}-mongodb-persistent-s2i.json \
+  {ImagePrefixVersion}-mongodb-s2i.json \
+  {ImagePrefixVersion}-mysql-persistent-s2i.json \
+  {ImagePrefixVersion}-mysql-s2i.json \
+  {ImagePrefixVersion}-postgresql-persistent-s2i.json \
+  {ImagePrefixVersion}-postgresql-s2i.json \
+ifndef::eap-openshift-online[  {ImagePrefixVersion}-third-party-db-s2i.json \]
+ifndef::eap-openshift-online[  {ImagePrefixVersion}-tx-recovery-s2i.json \]
+  {ImagePrefixVersion}-sso-s2i.json
+do
+  oc replace --force -f \
+{ImageandTemplateImportURL}${resource}
+done
+----
+
+[NOTE]
+====
+The {ProductShortName} image streams and templates imported using the above command are only available within that OpenShift project.
+
+If you have administrative access to the general `openshift` namespace and want the image streams and templates to be accessible by all projects, add `-n openshift` to the `oc replace` line of the command. For example:
+
+[options="nowrap"]
+----
+...
+oc replace -n openshift --force -f \
+...
+----
+====

--- a/shared-doc/cd-openshift-getting-started.adoc
+++ b/shared-doc/cd-openshift-getting-started.adoc
@@ -1,0 +1,9 @@
+[[getting_started_with_openshift]]
+= Getting Started with OpenShift
+
+This document contains the basic instructions to build and deploy this quickstart to {xpaasproduct-shortname} or {xpaasproductOpenShiftOnline-shortname}.
+
+
+See link:{LinkOpenShiftGuide}[_{EapForOpenshiftBookName}_] for more detailed information about building and running applications on {xpaasproduct-shortname}.
+
+See link:{LinkOpenShiftOnlineGuide}[_{EapForOpenshiftBookName}_] for more detailed information about building and running applications on {xpaasproductOpenShiftOnline-shortname}.

--- a/shared-doc/cd-post-deployment-tasks.adoc
+++ b/shared-doc/cd-post-deployment-tasks.adoc
@@ -1,0 +1,37 @@
+[[post_deployment]]
+= OpenShift Post Deployment Tasks
+
+Depending on your application, some tasks might need to be performed after your OpenShift application has been built and deployed. This might include exposing a service so that the application is viewable from outside of OpenShift, or scaling your application to a specific number of replicas.
+
+. Get the service name of the quickstart application using the following command.
++
+[options="nowrap",subs="+quotes"]
+----
+$ oc get service
+----
+. Expose the main service as a route so you can access the application from outside of OpenShift. For example, for the `{artifactId}` quickstart, use the following command to expose the required service and port.
++
+[options="nowrap",subs="+quotes"]
+----
+$ oc expose service/__eap-app__ --port=__8080__
+----
++
+[NOTE]
+====
+If you used a template to create the application, the route might already exist. If it does, continue on to the next step.
+====
+. Get the URL of the route.
++
+[options="nowrap"]
+----
+$ oc get route
+----
+. Access the application in your web browser using the URL. The URL is the value of the `HOST/PORT` field from previous command's output.
++
+If your application does not use the {ProductShortName} root context, append the context of the application to the URL. For example, for the `kitchensink` quickstart, the URL might be `http://__HOST_PORT_VALUE__/{artifactId}/`.
+. Optionally, you can also scale up the application instance by running the following command. This increases the number of replicas to `3`.
++
+[options="nowrap",subs="+quotes"]
+----
+$ oc scale deploymentconfig eap-app --replicas=3
+----

--- a/shopping-cart/README.adoc
+++ b/shopping-cart/README.adoc
@@ -1,28 +1,22 @@
+include::../shared-doc/attributes.adoc[]
+
 = shopping-cart: EJB Stateful Session Bean (SFSB) Example
 :author: Serge Pagop
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
-include::../shared-doc/attributes.adoc[]
-:standalone-server-type: default
-
 :level: Intermediate
 :technologies: SFSB EJB
-:source: {githubRepoUrl}
 
 [abstract]
-The `shopping-cart` quickstart demonstrates how to deploy and run a simple Java EE 7 shopping cart application that uses a stateful session bean (SFSB).
+The `shopping-cart` quickstart demonstrates how to deploy and run a simple {javaVersion} shopping cart application that uses a stateful session bean (SFSB).
 
 :standalone-server-type: default
 :archiveType: jar
 :archiveDir: {artifactId}/server/target
 :includes-cli-scripts:
+:restoreScriptName: restore-system-exception.cli
 
 == What is it?
 
-The `shopping-cart` quickstart demonstrates how to deploy and run a simple Java EE 7 application that uses a stateful session bean (SFSB) in {productNameFull}. The application allows customers to buy, checkout, and view their cart contents.
+The `shopping-cart` quickstart demonstrates how to deploy and run a simple {javaVersion} application that uses a stateful session bean (SFSB) in {productNameFull}. The application allows customers to buy, checkout, and view their cart contents.
 
 The `shopping-cart` application consists of the following:
 
@@ -34,28 +28,13 @@ This standalone Java EE module is a JAR containing EJBs. It is responsible for m
 +
 This simple Java client is launched using a `main` method. The remote client looks up a reference to the server module's API, via JNDI. It then uses this API to perform the operations the customer requests.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Back up the server configuration files
-//*************************************************
-// == Back Up the {productName} Standalone Server Configuration
+// Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
 [[configure_the_server]]
@@ -106,16 +85,10 @@ You should see the following configuration in the `ejb3` subsystem.
 <log-system-exceptions value="false"/>
 ----
 
-//*************************************************
-// Install the quickstart parent artifact
-//*************************************************
-// == Install the Quickstart Parent Artifact in Maven
+// Install the Quickstart Parent Artifact in Maven
 include::../shared-doc/install-quickstart-parent-artifact.adoc[leveloffset=+1]
 
-//*************************************************
-// Build and deploy the quickstart JAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 // Additional deployment information
@@ -187,18 +160,9 @@ Cart was correctly removed, as expected, after Checkout
 INFO  [stdout] (pool-9-thread-8) implementing checkout() left as exercise for the reader!
 ----
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//************************************************************
 // Restore the {productName} Standalone Server Configuration
-//************************************************************
-// == Restore the {productName} Standalone Server Configuration
-:restoreScriptName: restore-system-exception.cli
 include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+1]
 
 // Additional information about this script
@@ -209,17 +173,9 @@ This script restores the the `log-system-exceptions` attribute value to `true`. 
 The batch executed successfully
 ----
 
-//******************************************************
-// Restore the standalone server configuration manually
-//******************************************************
-// == Restore the {productName} Standalone Server Configuration Manually
+// Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -231,8 +187,5 @@ This quickstart consists of multiple projects, so it deploys and runs differentl
 * To undeploy the project, right-click on the *{artifactId}-server* project and choose *Run As* –> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
 * Make sure you xref:restore_the_server_configuration[restore the {productName} standalone server configuration] when you have completed testing this quickstart.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/spring-greeter/README.adoc
+++ b/spring-greeter/README.adoc
@@ -1,21 +1,19 @@
-= spring-greeter: Greeter Example using Spring 4.x
-:author: Marius Bogoevici
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= spring-greeter: Greeter Example using Spring 4.x
+:author: Marius Bogoevici
 :level: Beginner
 :technologies: Spring MVC, JSP, JPA
-:source: {githubRepoUrl}
 
 [abstract]
 The `spring-greeter` quickstart is based on the `greeter` quickstart, but differs in that it uses Spring MVC for Mapping `GET` and `POST` requests.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -45,27 +43,18 @@ The user is added and a message displays the new user ID number.
 . Click on the *Greet a user!* link to return to the *Greet!* page.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 // Additional deployment information
@@ -75,33 +64,16 @@ If you do not have Maven configured you can manually copy `target/spring-greeter
 
 The application will be running at the following URL: http://localhost:8080/{artifactId}/
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
 // Additional undeploy information.
 Or you can manually remove the application by removing `{artifactId}.war` from the `__{jbossHomeName}__/standalone/deployments/` directory.
 
-//*************************************************
-// Run the Arquillian functional tests
-//*************************************************
-// == Run the Arquillian Functional Tests
+// Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
 
 == Debug the Application
 
@@ -112,3 +84,24 @@ If you want to debug the source code or look at the Javadocs of any library in t
 $ mvn dependency:sources
 $ mvn dependency:resolve -Dclassifier=javadoc
 ----
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/spring-kitchensink-basic/README.adoc
+++ b/spring-kitchensink-basic/README.adoc
@@ -1,25 +1,23 @@
-= spring-kitchensink-basic: Kitchensink Example using Spring 4.x
-:author: Marius Bogoevici, Tejas Mehta, Joshua Wilson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= spring-kitchensink-basic: Kitchensink Example using Spring 4.x
+:author: Marius Bogoevici, Tejas Mehta, Joshua Wilson
 :level: Intermediate
 :technologies: JSP, JPA, JSON, Spring, JUnit
-:source: {githubRepoUrl}
 
 [abstract]
-The `spring-kitchensink-basic` quickstart is an example of a Java EE 7 application using JSP, JPA and Spring 4.x.
+The `spring-kitchensink-basic` quickstart is an example of a {javaVersion} application using JSP, JPA and Spring 4.x.
 
 :standalone-server-type: default
 :archiveType: war
 
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
+
 == What is it?
 
-The `spring-kitchensink-basic` quickstart is an example of a Java EE 7 application using JSP, JPA and Spring 4.x in {productNameFull}. It
+The `spring-kitchensink-basic` quickstart is an example of a {javaVersion} application using JSP, JPA and Spring 4.x in {productNameFull}. It
 includes a persistence unit and some sample persistence and transaction code to introduce you to database access in enterprise Java:
 
 * In the `jboss-as-spring-mvc-context.xml` file, the `context:component-scan`
@@ -32,58 +30,30 @@ and `mvc:annotation-driven` elements are used to register both the non-rest and 
 * The datasource and entitymanager are retrieved via JNDI.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the application
 
 The application will be running at the following URL: http://localhost:8080/{artifactId}/.
 
-
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Run the Arquillian functional tests
-//*************************************************
-// == Run the Arquillian Functional Tests
+// Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
 
 == Debug the Application
 
@@ -95,3 +65,24 @@ commands to pull them into your local repository. The IDE should then detect the
 $ mvn dependency:sources
 $ mvn dependency:resolve -Dclassifier=javadoc
 ----
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/spring-kitchensink-springmvctest/README.adoc
+++ b/spring-kitchensink-springmvctest/README.adoc
@@ -1,21 +1,19 @@
-= spring-kitchensink-springmvctest: Kitchensink MVC Example Using Spring 4.x
-:author: Marius Bogoevici, Tejas Mehta, Joshua Wilson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= spring-kitchensink-springmvctest: Kitchensink MVC Example Using Spring 4.x
+:author: Marius Bogoevici, Tejas Mehta, Joshua Wilson
 :level: Intermediate
 :technologies: JSP, JPA, JSON, Spring, JUnit
-:source: {githubRepoUrl}
 
 [abstract]
 The  `spring-kitchensink-springmvctest` quickstart demonstrates how to create an MVC application using JSP, JPA and Spring 4.x.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -35,60 +33,30 @@ and `mvc:annotation-driven` elements are used to register both the non-rest and 
 * The datasource and entitymanager are retrieved via JNDI.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
 The application will be running at the following URL: http://localhost:8080/{artifactId}/.
 
-
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Run the Arquillian functional tests
-//*************************************************
-// == Run the Arquillian Functional Tests
+// Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
 
 == Debug the Application
 
@@ -100,3 +68,24 @@ commands to pull them into your local repository. The IDE should then detect the
 $ mvn dependency:sources
 $ mvn dependency:resolve -Dclassifier=javadoc
 ----
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/spring-resteasy/README.adoc
+++ b/spring-resteasy/README.adoc
@@ -1,15 +1,9 @@
-= spring-resteasy: Example Using Resteasy Spring Integration
-:author: Weinan Li <l.weinan@gmail.com>, Paul Gier <pgier@redhat.com>
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= spring-resteasy: Example Using Resteasy Spring Integration
+:author: Weinan Li <l.weinan@gmail.com>, Paul Gier <pgier@redhat.com>
 :level: Beginner
 :technologies: Resteasy, Spring
-:source: {githubRepoUrl}
 
 [abstract]
 The `spring-resteasy` quickstart demonstrates how to package and deploy a web application that includes resteasy-spring integration.
@@ -18,35 +12,30 @@ The `spring-resteasy` quickstart demonstrates how to package and deploy a web ap
 :archiveType: war
 :jbds-not-supported:
 
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
+
 == What is it?
 
 The `spring-resteasy` quickstart demonstrates how to package and deploy a web application, which includes resteasy-spring integration, in
 {productNameFull}.
 
+
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -69,26 +58,30 @@ And the same set as above but using the `locating` path.
 * http://localhost:8080/{artifactId}/locating/uriParam/789[{artifactId}/locating/uriParam/789]
 
 
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/tasks-jsf/README.adoc
+++ b/tasks-jsf/README.adoc
@@ -1,15 +1,9 @@
-= tasks-jsf: JSF, JPA quickstart
-:author: Lukas Fryc
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= tasks-jsf: JSF, JPA quickstart
+:author: Lukas Fryc
 :level: Intermediate
 :technologies: JSF, JPA
-:source: {githubRepoUrl}
 :prerequisites: link:tasks/README{outfilesuffix}[tasks]
 
 [abstract]
@@ -17,6 +11,13 @@ The `tasks-jsf` quickstart demonstrates how to use JPA persistence with JSF as t
 
 :standalone-server-type: default
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
+:performance-scalability:
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -31,37 +32,21 @@ JSF is used to present the user two views.
 * authentication form: This provides the simple login
 * task view: This view contains the task list, a task detail, and a task addition form. The task view uses AJAX.
 
-//***************************************
-// Add notes about use in a production environment.
-//***************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
-:performance-scalability:
+//*************************************************
+// Product Release content only
+//*************************************************
+
+ifndef::EAPCDRelease[]
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -79,32 +64,12 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
 
 == Debug the Application
 
@@ -114,3 +79,24 @@ If you want to debug the source code of any library in the project, run the foll
 ----
 $ mvn dependency:sources
 ----
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/tasks-rs/README.adoc
+++ b/tasks-rs/README.adoc
@@ -1,15 +1,9 @@
-= tasks-rs: JAX-RS, JPA quickstart
-:author: Mike Musgrove
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= tasks-rs: JAX-RS, JPA quickstart
+:author: Mike Musgrove
 :level: Intermediate
 :technologies: JPA, JAX-RS
-:source: {githubRepoUrl}
 :prerequisites: link:tasks/README{outfilesuffix}[tasks]
 
 [abstract]
@@ -17,6 +11,9 @@ The `tasks-rs` quickstart demonstrates how to implement a JAX-RS service that us
 
 :standalone-server-type: default
 :archiveType: war
+:uses-h2:
+:uses-ds-xml:
+:app-user-groups: guest
 
 == What is it?
 
@@ -28,45 +25,19 @@ The `tasks-rs` quickstart demonstrates how to implement a JAX-RS service that us
 
 The application manages `User` and `Task` JPA entities. A user represents an authenticated principal and is associated with zero or more tasks. Service methods validate that there is an authenticated principal and the first time a principal is seen, a JPA User entity is created to correspond to the principal. JAX-RS annotated methods are provided for associating tasks with this user and for listing and removing tasks.
 
-//*************************************************
-// Add notes about use in a production environment.
-//*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
-:uses-ds-xml:
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
 // Add the Authorized Application User
-//*************************************************
-// == Add the Authorized Application User
-:app-user-groups: guest
 include::../shared-doc/add-application-user.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application Resources
 
@@ -283,30 +254,15 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+//  Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
 Make sure you xref:add_the_application_user[add the authorized application user].
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/temperature-converter/README.adoc
+++ b/temperature-converter/README.adoc
@@ -1,21 +1,19 @@
-= temperature-converter: Stateless Session EJB (SLSB)
-:author: Bruce Wolfe
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= temperature-converter: Stateless Session EJB (SLSB)
+:author: Bruce Wolfe
 :level: Beginner
 :technologies: CDI, JSF, SLSB EJB
-:source: {githubRepoUrl}
 
 [abstract]
 The `temperature-converter` quickstart does temperature conversion using an EJB Stateless Session Bean (SLSB), CDI, and a JSF front-end client.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -29,30 +27,21 @@ The application does the following:
 . The response from TemperatureConvertEJB is stored in the `temperature` field of the managed bean.
 . The managed bean is annotated as @SessionScoped, so the same managed bean instance is used for the entire session.
 
+
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -64,28 +53,31 @@ You will be presented with a simple form for temperature conversion.
 . Enter a temperature.
 . Press the `Convert` button to see the results.
 
-
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/template/README.adoc
+++ b/template/README.adoc
@@ -1,3 +1,5 @@
+include::../shared-doc/attributes.adoc[]
+
 = How to Structure and Write a Quickstart README.adoc File
 
 == Introduction

--- a/thread-racing/README.adoc
+++ b/thread-racing/README.adoc
@@ -1,30 +1,28 @@
+include::../shared-doc/attributes.adoc[]
+
 = thread-racing: A Java EE thread racing web application
 :author: Eduardo Martins
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
-include::../shared-doc/attributes.adoc[]
-:uses-h2:
-
 :level: Beginner
 :technologies: Batch, CDI, EE Concurrency, JAX-RS, JMS, JPA, JSON, Web Sockets
-:source: {githubRepoUrl}
 
 [abstract]
 A thread racing web application that demonstrates technologies introduced or updated in the latest Java EE specification.
 
 :standalone-server-type: full
 :archiveType: war
+:uses-h2:
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
-The `thread-racing` quickstart is a web application that demonstrates new and updated technologies introduced by the Java EE 7 specification through simple use cases.
+The `thread-racing` quickstart is a web application that demonstrates new and updated technologies introduced by the {javaVersion} specification through simple use cases.
 
 The web application allows the user to trigger a race between 4 threads and follow, in real time, the progress of each thread until the race ends.
 
-The race itself consists of multiple stages, each demonstrating the usage of a specific new or updated Java EE 7 technology:
+The race itself consists of multiple stages, each demonstrating the usage of a specific new or updated {javaVersion} technology:
 
 * Batch 1.0
 * EE Concurrency 1.0
@@ -32,42 +30,27 @@ The race itself consists of multiple stages, each demonstrating the usage of a s
 * JMS 2.0
 * JSON 1.0
 
-WebSockets 1.0 is one of the most relevant new technologies introduced by Java EE 7. Instead of being used in a race stage, a WebSockets 1.0 ServerEndpoint provides the remote application interface.
+WebSockets 1.0 is one of the most relevant new technologies introduced by {javaVersion}. Instead of being used in a race stage, a WebSockets 1.0 ServerEndpoint provides the remote application interface.
 A new race is run when a client establishes a session. That session is then used to update the client in real time, with respect to the race progress and results. The `src/main/java/org/jboss/as/quickstarts/threadracing/WebSocketRace.java` file is the WebSocket server endpoint class and is a good entry point when studying how the application code works.
 
 JPA 2.1 is also present in the application code. Specifically it is used to store race results in the default data source instance, which is also new to Java EE. Further details are included in the `src/main/java/org/jboss/as/quickstarts/threadracing/results/RaceResults.java` class.
 
+
 //*************************************************
-// Add notes about use in a production environment.
+// Product Release content only
 //*************************************************
-// == Considerations for Use in a Production Environment
-:uses-h2:
+
+ifndef::EAPCDRelease[]
+
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
-
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the full profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-== Build and Deploy the Quickstart
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 
@@ -85,31 +68,35 @@ NOTE: You will see the following warning in the server log. You can ignore this 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
 NOTE: Within JBoss Developer Studio, make sure you define a server runtime environment that uses the `standalone-full.xml` configuration file.
 
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
+// Debug the Application
+include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
 
 //*************************************************
-// Add info to debug the application
+// CD Release content only
 //*************************************************
-// == Debug the Application
-include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/websocket-client/README.adoc
+++ b/websocket-client/README.adoc
@@ -1,21 +1,19 @@
-= websocket-client: WebSocket Java Client Example
-:author: Paul Cowan
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= websocket-client: WebSocket Java Client Example
+:author: Paul Cowan
 :level: Intermediate
 :technologies: Web Socket, CDI Events, JSON, SSL
-:source: {githubRepoUrl}
 
 [abstract]
 Demonstrates use of a Javascript WebSocket client, WebSocket configuration, programmatic binding, and secure WebSocket.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -35,27 +33,18 @@ The remote WebSocket server must be an `Echo` server; a simple WebSocket server 
 `Backend` does not use WebSocket annotations because it demonstrates how to use `ClientEndpointConfig` to configure the WebSocket client to connect to a secure (wss) WebSocket.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+//  Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -82,29 +71,31 @@ RECV: Received message from backend session __BACKEND_SESSION_ID__
 RECV: This is a test
 ----
 
-
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]

--- a/websocket-endpoint/README.adoc
+++ b/websocket-endpoint/README.adoc
@@ -1,21 +1,19 @@
-= websocket-endpoint: Web application using WebSockets and JSON-P
-:author: Rafael Benevides
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= websocket-endpoint: Web application using WebSockets and JSON-P
+:author: Rafael Benevides
 :level: Beginner
 :technologies: CDI, WebSocket, JSON-P
-:source: {githubRepoUrl}
 
 [abstract]
 Shows how to use WebSockets with JSON to broadcast information to all open WebSocket sessions in {productName}.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -26,29 +24,19 @@ The `BidWebSocketEndpoint` provides the WebSocket endpoint that receives `Messag
 Every update made on the `Bidding` are immediately propagated to all opened WebSocket sessions without any browser submission or AJAX polling mechanism.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the application
 
@@ -62,30 +50,32 @@ You should open the application URL in other browsers or tabs. You will notice t
 
 You can restart the bidding if you click on `Reset bidding` button.
 
-
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/websocket-hello/README.adoc
+++ b/websocket-hello/README.adoc
@@ -1,21 +1,19 @@
-= websocket-hello: A simple WebSocket application
-:author: Sande Gilda, Emmanuel Hugonett
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= websocket-hello: A simple WebSocket application
+:author: Sande Gilda, Emmanuel Hugonett
 :level: Beginner
 :technologies: WebSocket, CDI, JSF
-:source: {githubRepoUrl}
 
 [abstract]
 The `websocket-hello` quickstart demonstrates how to create a simple WebSocket application.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -25,32 +23,23 @@ The `websocket-hello` quickstart demonstrates how to create a simple WebSocket-e
 * A WebSocket server endpoint that uses annotations to interact with the WebSocket events.
 * A `jboss-web.xml` file configured to enable WebSockets
 
-WebSockets are a requirement of the Java EE 7 specification and are implemented in {productName} {productVersion}. They are configured in the `undertow` subsystem of the server configuration file. This quickstart uses the WebSocket default settings, so it is not necessary to modify the server configuration to deploy and run this quickstart.
+WebSockets are a requirement of the {javaVersion} specification and are implemented in {productName} {productVersion}. They are configured in the `undertow` subsystem of the server configuration file. This quickstart uses the WebSocket default settings, so it is not necessary to modify the server configuration to deploy and run this quickstart.
 
 NOTE: This quickstart demonstrates only a few of the basic functions. A fully functional application should provide better error handling and intercept and handle additional events.
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the Application
@@ -67,29 +56,31 @@ The application will be running at the following URL: http://localhost:8080/{art
 WebSocket connection is not established. Please click the Open Connection button.
 ----
 
-
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+// Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+

--- a/wicket-ear/README.adoc
+++ b/wicket-ear/README.adoc
@@ -1,22 +1,19 @@
-= wicket-ear: Wicket Framework used in a WAR inside an EAR.
-:author: Ondrej Zizka <ozizka@redhat.com>
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= wicket-ear: Wicket Framework used in a WAR inside an EAR.
+:author: Ondrej Zizka <ozizka@redhat.com>
 :level: Intermediate
 :technologies: Apache Wicket, JPA
-:source: {githubRepoUrl}
 
 [abstract]
 Demonstrates how to use the Wicket Framework 7.x with the JBoss server using the Wicket Java EE integration, packaged as an EAR
 
+:standalone-server-type: default
+:archiveType: ear
+
 == What is it?
 
-This is an example of how to use Wicket Framework 7.x with WildFly, leveraging features of Java EE 7, using the Wicket Java EE integration.
+This is an example of how to use Wicket Framework 7.x with WildFly, leveraging features of {javaVersion}, using the Wicket Java EE integration.
 
 Features used:
 
@@ -34,72 +31,26 @@ This is an EAR version, with the following structure:
         - `ear`: Packages the EJB JAR and WAR into an EAR. Creates an `.ear` file
 ----
 
-== System requirements
+// System Requirements
+include::../shared-doc/system-requirements.adoc[leveloffset=+1]
+//  Use of {jbossHomeName}
+include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
+//  Start the {productName} Standalone Server
+include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
+//  Build and Deploy the Quickstart
+include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
-All you need to build this project is Java 8 (Java SDK 1.8) or better, Maven 3.1 or better.
+== Access the application
 
-The application this project produces is designed to be run on JBoss WildFly.
-
-== Configure Maven
-
-If you have not yet done so, you must link:../README.md#mavenconfiguration[Configure Maven] before testing the quickstarts.
-
-== Start JBoss WildFly with the Web Profile
-
-. Open a command line and navigate to the root of the JBoss server directory.
-. 
-
-The following shows the command line to start the server with the web profile:
-
-[source]
-----
-For Linux:   JBOSS_HOME/bin/standalone.sh
-For Windows: JBOSS_HOME\bin\standalone.bat
-----
-
-== Build and Deploy the Quickstart
-
-_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See link:../README.md#buildanddeploy[Build and Deploy the Quickstarts] for complete instructions and additional options._
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-Type this command to build and deploy the archive:
-
-[source]
-----
-mvn clean package wildfly:deploy
-----
-
-. 
-
-This will deploy `target/wildfly-wicket-ear.ear` to the running instance of the server.
-
-Access the application
-———————-
-
-The application will be running at the following URL: http://localhost:8080/wildfly-wicket-ear-war/[http://localhost:8080/wildfly-wicket-ear-war/].
+The application will be running at the following URL: http://localhost:8080/{artifactId}/
 
 * You will see a page with a table listing the existing Contact entities. Initially, this table is empty.
-* Click on the _Insert a new Constact_ link to add a new contact.
+* Click on the *Insert a new Constact* link to add a new contact.
 
-== Undeploy the Archive
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-When you are finished testing, type this command to undeploy the archive:
-
-[source]
-----
-mvn wildfly:undeploy
-----
-
-== Run the Quickstart in JBoss Developer Studio or Eclipse
-
-You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see link:../README.md#useeclipse[Use JBoss Developer Studio or Eclipse to Run the Quickstarts] 
+// Undeploy the Quickstart
+include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application
 

--- a/wicket-war/README.adoc
+++ b/wicket-war/README.adoc
@@ -1,22 +1,19 @@
-= wicket-war: Wicket Framework used in a WAR.
-:author: Ondrej Zizka <ozizka@redhat.com>
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= wicket-war: Wicket Framework used in a WAR.
+:author: Ondrej Zizka <ozizka@redhat.com>
 :level: Intermediate
 :technologies: Apache Wicket, JPA
-:source: {githubRepoUrl}
 
 [abstract]
 Demonstrates how to use the Wicket Framework 7.x with the JBoss server using the Wicket Java EE integration packaged as a WAR
 
+:standalone-server-type: default
+:archiveType: war
+
 == What is it?
 
-This is an example of how to use Wicket Framework 7.x with WildFly, leveraging features of Java EE 7, using the Wicket-Stuff Java EE integration.
+This is an example of how to use Wicket Framework 7.x with WildFly, leveraging features of {javaVersion}, using the Wicket-Stuff Java EE integration.
 
 Features used:
 
@@ -26,66 +23,23 @@ Features used:
 
 This is a WAR version.
 
-== System requirements
-
-All you need to build this project is Java 8 (Java SDK 1.8) or better, Maven 3.1 or better.
-
-The application this project produces is designed to be run on JBoss WildFly.
-
-== Configure Maven
-
-If you have not yet done so, you must link:../README.md#mavenconfiguration[Configure Maven] before testing the quickstarts.
-
-== Start JBoss WildFly with the Web Profile
-
-. Open a command line and navigate to the root of the JBoss server directory.
-. 
-
-The following shows the command line to start the server with the web profile:
-
-[source]
-----
-For Linux:   JBOSS_HOME/bin/standalone.sh
-For Windows: JBOSS_HOME\bin\standalone.bat
-----
-
-== Build and Deploy the Quickstart
-
-_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See link:../README.md#buildanddeploy[Build and Deploy the Quickstarts] for complete instructions and additional options._
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-Type this command to build and deploy the archive:
-
-[source]
-----
-mvn clean package wildfly:deploy
-----
-
-. 
-
-This will deploy `target/wildfly-wicket-war.war` to the running instance of the server.
+// System Requirements
+include::../shared-doc/system-requirements.adoc[leveloffset=+1]
+//  Use of {jbossHomeName}
+include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
+//  Start the {productName} Standalone Server
+include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
+//  Build and Deploy the Quickstart
+include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 == Access the application
 
-Access the running application in a browser at the following URL: http://localhost:8080/wildfly-wicket-war[http://localhost:8080/wildfly-wicket-war]
+Access the running application in a browser at the following URL: http://localhost:8080/{artifactId}/
 
 You will see a page with a table listing user entities. Initially, this table is empty. By clicking a link, you can add more users.
 
-== Undeploy the Archive
-
-. Make sure you have started the JBoss Server as described above.
-. Open a command line and navigate to the root directory of this quickstart.
-. 
-
-When you are finished testing, type this command to undeploy the archive:
-
-[source]
-----
-mvn wildfly:undeploy
-----
+// Undeploy the Quickstart
+include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
 == Debug the Application
 

--- a/wsat-simple/README.adoc
+++ b/wsat-simple/README.adoc
@@ -1,15 +1,9 @@
-= wsat-simple: WS-AT (WS-AtomicTransaction) - Simple
-:author: Paul Robinson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= wsat-simple: WS-AT (WS-AtomicTransaction) - Simple
+:author: Paul Robinson
 :level: Intermediate
 :technologies: WS-AT, JAX-WS
-:source: {githubRepoUrl}
 
 [abstract]
 The `wsat-simple` quickstart demonstrates a WS-AT (WS-AtomicTransaction) enabled JAX-WS Web service, bundled as a WAR, and deployed to {productName}.
@@ -49,16 +43,9 @@ When running the `org.jboss.as.quickstarts.wsat.simple.ClientTest#testCommit()` 
 
 There is another test that shows what happens if the client decides to rollback the AT.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 [[start_the_eap_standalone_server]]
@@ -85,11 +72,7 @@ $ __{jbossHomeName}__/bin/standalone.sh --server-config=../../docs/examples/conf
 +
 NOTE: For Windows, use the `__{jbossHomeName}__\bin\standalone.bat` script.
 
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
 
 
@@ -164,10 +147,7 @@ Test commit:
 
 NOTE: You can ignore the warning message `ARJUNA043219: Could not save recovery state for non-serializable durable WS-AT participant restaurantServiceAT` that is printed in the server console. This quickstart does not implement the required recovery hooks in the interest of making it easy to follow. In a real world production application, you should provide the required recovery code. For more information, see http://narayana.io/docs/product.
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -193,8 +173,5 @@ This quickstart is more complex than the others. It requires that you configure 
 . Start the new *{productName} XTS Configuration* server.
 . Right-click on the *{artifactId}* project, choose *Run As* -> *Maven build*, enter `clean verify -Parq-remote` for the *Goals*, and click *Run* to run the Arquillian tests. The test results appear in the console.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/wsba-coordinator-completion-simple/README.adoc
+++ b/wsba-coordinator-completion-simple/README.adoc
@@ -1,15 +1,9 @@
-= wsba-coordinator-completion-simple: Example of a WS-BA Enabled JAX-WS Web Service
-:author: Paul Robinson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= wsba-coordinator-completion-simple: Example of a WS-BA Enabled JAX-WS Web Service
+:author: Paul Robinson
 :level: Intermediate
 :technologies: WS-BA, JAX-WS
-:source: {githubRepoUrl}
 
 [abstract]
 The `wsba-coordinator-completion-simple` quickstart deploys a WS-BA (WS Business Activity) enabled JAX-WS Web service WAR (CoordinatorCompletion protocol).
@@ -51,16 +45,9 @@ When running the `org.jboss.as.quickstarts.wsba.coordinatorcompletion.simple.Cli
 
 There is another test that shows how the client can cancel a BA.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 [[start_the_eap_standalone_server]]
@@ -80,13 +67,8 @@ NOTE: For Windows, use the `__{jbossHomeName}__\bin\standalone.bat` script.
 
 The pipe to egrep, `| egrep "started|stdout"`, is useful to show when the server has started and the output from these tests. For normal operation, this pipe can be removed.
 
-
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
 
 [[investigate_the_console_output]]
 == Investigate the Console Output
@@ -162,10 +144,7 @@ Test cancel:
 16:24:19,816 INFO  [stdout] (TaskWorker-3) [SERVICE] Compensate the backend resource by removing '2' from the set (e.g. undo any changes to databases that were previously made visible to others)
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -192,9 +171,5 @@ This quickstart is more complex than the others. It requires that you configure 
 . Start the new *{productName} XTS Configuration* server.
 . Right-click on the *{artifactId}* project, choose *Run As* -> *Maven build*, enter `clean verify -Parq-remote` for the *Goals*, and click *Run* to run the Arquillian tests. The test results appear in the console.
 
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/wsba-participant-completion-simple/README.adoc
+++ b/wsba-participant-completion-simple/README.adoc
@@ -1,15 +1,9 @@
-= wsba-participant-completion-simple: Deployment of a WS-BA enabled JAX-WS Web Service
-:author: Paul Robinson
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= wsba-participant-completion-simple: Deployment of a WS-BA enabled JAX-WS Web Service
+:author: Paul Robinson
 :level: Intermediate
 :technologies: WS-BA, JAX-WS
-:source: {githubRepoUrl}
 
 [abstract]
 The `wsba-participant-completion-simple` quickstart deploys a WS-BA (WS Business Activity) enabled JAX-WS Web service WAR (ParticipantCompletion Protocol).
@@ -56,16 +50,9 @@ There are additional tests that show:
 * What happens when an application exception is thrown by the service.
 * How the client can cancel a BA.
 
-//*************************************************
-// Add System Requirements
-//*************************************************
-// == System Requirements
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 [[start_the_eap_standalone_server]]
@@ -85,10 +72,7 @@ NOTE: For Windows, use the `__{jbossHomeName}__\bin\standalone.bat` script.
 
 The pipe to egrep, `| egrep "started|stdout"`, is useful to show when the server has started and the output from these tests. For normal operation, this pipe can be removed.
 
-//*************************************************
-// Run the Arquillian tests
-//*************************************************
-// == Run the Arquillian Tests
+// Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
 
 
@@ -157,10 +141,7 @@ INFO  [stdout] (http-localhost-127.0.0.1-8080-1) [SERVICE] Prepare successful, n
 INFO  [stdout] (http-localhost-127.0.0.1-8080-1) [SERVICE] Participant.confirmCompleted('true') (This tells the participant that compensation information has been logged and that it is safe to commit any changes.)
 ----
 
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBoss Developer Studio instructions
@@ -186,8 +167,5 @@ This quickstart is more complex than the others. It requires that you configure 
 . Start the new *{productName} XTS Configuration* server.
 . Right-click on the *{artifactId}* project, choose *Run As* -> *Maven build*, enter `clean verify -Parq-remote` for the *Goals*, and click *Run* to run the Arquillian tests. The test results appear in the console.
 
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+// Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/xml-jaxp/README.adoc
+++ b/xml-jaxp/README.adoc
@@ -1,21 +1,19 @@
-= xml-jaxp: Upload and Parse an XML File Using DOM or SAX
-:author: Bartosz Baranowski
-:productName: WildFly
-:productNameFull: WildFly Application Server
-:jbossHomeName: WILDFLY_HOME
-:productVersion: 12
-:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
 include::../shared-doc/attributes.adoc[]
 
+= xml-jaxp: Upload and Parse an XML File Using DOM or SAX
+:author: Bartosz Baranowski
 :level: Intermediate
 :technologies: JAXP, SAX, DOM, Servlet
-:source: {githubRepoUrl}
 
 [abstract]
 The `xml-jaxp` quickstart demonstrates how to use Servlet and JSF to upload an XML file to {productName} and validate and parse it using DOM or SAX.
 
 :standalone-server-type: default
 :archiveType: war
+
+//*************************************************
+// Shared CD and Product Release content
+//*************************************************
 
 == What is it?
 
@@ -27,29 +25,19 @@ This quickstart provides an example XML schema and document file to use when tes
 * The XML document is located here: `__QUICKSTART_HOME__/src/main/resources/catalog.xml`
 
 //*************************************************
-// Add System Requirements
+// Product Release content only
 //*************************************************
-// == System Requirements
+
+ifndef::EAPCDRelease[]
+
+// System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
-
-//*************************************************
-// Add Use of JBoss Home Name
-//*************************************************
-// == Use of {jbossHomeName}
+// Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
-
-//*************************************************
-// Start the server with the default profile
-//*************************************************
-// == Start the {productName} Standalone Server
+// Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
-
-//*************************************************
-// Build and deploy the quickstart WAR
-//*************************************************
-// == Build and Deploy the Quickstart
+// Build and Deploy the Quickstart
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
-
 
 == Access the Application
 
@@ -79,28 +67,31 @@ To enable the alternative SAXXMLParser parser:
 INFO  [stdout] (http-/127.0.0.1:8080-1) Parsing the document using the SAXXMLParser!
 ----
 
-
-//*************************************************
-// Undeploy the quickstart archive
-//*************************************************
-// == Undeploy the Quickstart
+//  Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-
-
-//*************************************************
-// Add JBoss Developer Studio instructions
-//*************************************************
-// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+// Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-//*************************************************
-// Deploy the quickstart to OpenShift
-//*************************************************
-// == Deploy the Quickstart to OpenShift Online
-include::../shared-doc/deploy-to-openshift-online.adoc[leveloffset=+1]
-
-//*************************************************
-// Add info to debug the application
-//*************************************************
-// == Debug the Application
+//  Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
+
+endif::[]
+
+//*************************************************
+// CD Release content only
+//*************************************************
+
+ifdef::EAPCDRelease[]
+
+// Getting Started with OpenShift
+include::../shared-doc/cd-openshift-getting-started.adoc[leveloffset=+1]
+//Prepare OpenShift for Quickstart Deployment
+include::../shared-doc/cd-create-project.adoc[leveloffset=+1]
+// Import the Latest {xpaasproduct-shortname} Image Streams and Templates
+include::../shared-doc/cd-import-imagestreams-templates.adoc[leveloffset=+1]
+// Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift
+include::../shared-doc/cd-deploy-project.adoc[leveloffset=+1]
+// OpenShift Post Deployment Tasks: This is not currently needed.
+// include::../shared-doc/cd-post-deployment-tasks.adoc[leveloffset=+1]
+
+endif::[]
+


### PR DESCRIPTION
I removed all common attributes for the product name, version, etc,  from the individual quickstart README files because they are defined in the shared-doc/attributes.adoc file. This should make them easier to maintain going forward. I also added conditional attributes (flags) for the build type (product vs. project) and the product release type (CD vs. JBoss EAP) to display the correct server names and instructions.

I won't be needing to update this commit again. I can make additional changes in another PR.

This one is ready for review.